### PR TITLE
Improve performance of Board::GetPieces

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -52,6 +52,8 @@ namespace Alphalcazar::Game {
 		/// Returns the tile at the given coordinates
 		Tile* GetTile(const Coordinates& coord);
 		Tile* GetTile(Coordinate x, Coordinate y);
+		const Tile* GetTile(const Coordinates& coord) const;
+		const Tile* GetTile(Coordinate x, Coordinate y) const;
 		/// Returns all tiles of the board
 		std::vector<const Tile*> GetTiles() const;
 		/// Returns all perimeter tiles of the board
@@ -61,10 +63,12 @@ namespace Alphalcazar::Game {
 
 		/// Returns the tile a given piece is placed on, or nullptr if the specified piece is not on the board
 		Tile* GetPieceTile(const Piece& piece);
-		/// Returns a list of all pieces in play on the board (including perimiter)
-		std::vector<std::pair<Coordinates, Piece>> GetPieces() const;
-		/// Returns a list of all pieces of the specified player in play on the board (including perimiter)
-		std::vector<std::pair<Coordinates, Piece>> GetPieces(PlayerId player) const;
+		/*!
+		 * \brief Returns a list of all pieces in play on the board (including perimeter)
+		 *
+		 * \param player If a valid player ID is specified, the function will only return pieces of this player
+		 */
+		std::vector<std::pair<Coordinates, Piece>> GetPieces(PlayerId player = PlayerId::NONE) const;
 	private:
 		/*!
 		 * \brief Executes one piece movement, if the specified piece is on the board

--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -75,7 +75,7 @@ namespace std {
 	};
 }
 
-// We define the specializations of parse & format to make \ref PlacementMove formattable. Based on: https://fmt.dev/latest/api.html#format-api
+// We define the specializations of parse & format to make \ref Coordinates formattable. Based on: https://fmt.dev/latest/api.html#format-api
 template <> struct fmt::formatter<Alphalcazar::Game::Coordinates> {
 	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
 		return ctx.begin();

--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -3,6 +3,8 @@
 #include "aliases.hpp"
 #include <unordered_map>
 
+#include <fmt/format.h>
+
 namespace Alphalcazar::Game {
 	/*!
 	 * \brief Helper class to work with the 2D coordinate system of the tiles of the board.
@@ -72,3 +74,15 @@ namespace std {
 		}
 	};
 }
+
+// We define the specializations of parse & format to make \ref PlacementMove formattable. Based on: https://fmt.dev/latest/api.html#format-api
+template <> struct fmt::formatter<Alphalcazar::Game::Coordinates> {
+	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+		return ctx.begin();
+	}
+
+	template <typename FormatContext>
+	auto format(const Alphalcazar::Game::Coordinates& coordinates, FormatContext& ctx) -> decltype(ctx.out()) {
+		return format_to(ctx.out(), "({},{})", coordinates.x, coordinates.y);
+	}
+};

--- a/cpp/src/game/include/game/PlacementMove.hpp
+++ b/cpp/src/game/include/game/PlacementMove.hpp
@@ -32,6 +32,6 @@ template <> struct fmt::formatter<Alphalcazar::Game::PlacementMove> {
 
     template <typename FormatContext>
     auto format(const Alphalcazar::Game::PlacementMove& move, FormatContext& ctx) -> decltype(ctx.out()) {
-        return format_to(ctx.out(), "Piece {} -> ({},{})", move.PieceType, move.Coordinates.x, move.Coordinates.y);
+        return format_to(ctx.out(), "Piece {} -> {}", move.PieceType, move.Coordinates);
     }
 };

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -245,6 +245,9 @@ namespace Alphalcazar::Game {
 		case PlayerId::PLAYER_TWO:
 			min = c_PieceTypes;
 			break;
+		default:
+			// Keep the default min/max to iterate over the complete array
+			break;
 		}
 
 		for (std::size_t i = min; i <= max; i++) {

--- a/cpp/src/game/tests/Board.cpp
+++ b/cpp/src/game/tests/Board.cpp
@@ -193,6 +193,7 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(board.GetTile(0, 2)->GetPiece(), nullptr);
 		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), nullptr);
 		EXPECT_EQ(board.GetTile(3, 1)->GetPiece(), nullptr);
+		EXPECT_EQ(board.GetPieces().size(), 1);
 	}
 
 	TEST(Board, PushablePiecesDontPushEachOther) {
@@ -209,6 +210,7 @@ namespace Alphalcazar::Game {
 
 		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
 		EXPECT_EQ(*board.GetTile(2, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PushablePieceType));
+		EXPECT_EQ(board.GetPieces().size(), 2);
 	}
 
 	TEST(Board, PushablePieceMovements) {
@@ -245,6 +247,7 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(*board.GetTile(3, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PushablePieceType));
 		EXPECT_EQ(*board.GetTile(1, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 5));
 		EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
+		EXPECT_EQ(board.GetPieces().size(), 5);
 	}
 
 	TEST(Board, PushingPieceMovements) {
@@ -265,6 +268,7 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
 		EXPECT_EQ(*board.GetTile(3, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 3));
 		EXPECT_EQ(board.GetTile(4, 2)->GetPiece(), nullptr);
+		EXPECT_EQ(board.GetPieces().size(), 2);
 	}
 
 	TEST(Board, PushingPiecesPushingEachOther) {
@@ -283,6 +287,8 @@ namespace Alphalcazar::Game {
 
 			EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
 			EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PusherPieceType));
+
+			EXPECT_EQ(board.GetPieces().size(), 2);
 		}
 
 		{
@@ -294,6 +300,8 @@ namespace Alphalcazar::Game {
 
 			EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), nullptr);
 			EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
+
+			EXPECT_EQ(board.GetPieces().size(), 1);
 		}
 	}
 
@@ -332,6 +340,8 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PusherPieceType));
 		EXPECT_EQ(board.GetTile(2, 4)->GetPiece(), nullptr);
 		EXPECT_EQ(board.GetTile(4, 1)->GetPiece(), nullptr);
+
+		EXPECT_EQ(board.GetPieces().size(), 4);
 	}
 
 	TEST(Board, LegalPlacementTiles) {
@@ -374,5 +384,46 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(*boardCopy.GetTile(1, 0)->GetPiece(), pieceTwo);
 		EXPECT_EQ(*boardCopy.GetTile(2, 0)->GetPiece(), pieceThree);
 		EXPECT_EQ(*boardCopy.GetTile(2, 2)->GetPiece(), pieceFour);
+	}
+
+	TEST(Board, GetBoardPieces) {
+		Board board{};
+		Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
+		Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
+		Piece pieceFourPlayerOne{ PlayerId::PLAYER_ONE, 4 };
+		Piece pieceFourPlayerTwo{ PlayerId::PLAYER_TWO, 4 };
+
+		board.PlacePiece({ 0, 1 }, pieceOnePlayerOne);
+		board.PlacePiece({ 1, 0 }, pieceOnePlayerTwo);
+		board.PlacePiece({ 2, 2 }, pieceFourPlayerOne, Direction::EAST);
+		board.PlacePiece({ 3, 3 }, pieceFourPlayerTwo, Direction::WEST);
+
+		{
+			auto pieces = board.GetPieces();
+			auto playerOnePieces = board.GetPieces(PlayerId::PLAYER_ONE);
+			auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
+			EXPECT_EQ(pieces.size(), 4);
+			EXPECT_EQ(playerOnePieces.size(), 2);
+			EXPECT_EQ(playerTwoPieces.size(), 2);
+			for (auto& [coordinates, piece] : pieces) {
+				// All pieces should be either type 1 or 4
+				EXPECT_TRUE(piece.GetType() == 4 || piece.GetType() == 1);
+			}
+		}
+
+
+		Piece pieceTwoPlayerTwo{ PlayerId::PLAYER_TWO, 2 };
+		Piece pieceThreePlayerTwo{ PlayerId::PLAYER_TWO, 3 };
+		board.PlacePiece({ 1, 1 }, pieceTwoPlayerTwo, Direction::EAST);
+		board.PlacePiece({ 2, 1 }, pieceThreePlayerTwo, Direction::WEST);
+
+		{
+			auto pieces = board.GetPieces();
+			auto playerOnePieces = board.GetPieces(PlayerId::PLAYER_ONE);
+			auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
+			EXPECT_EQ(pieces.size(), 6);
+			EXPECT_EQ(playerOnePieces.size(), 2);
+			EXPECT_EQ(playerTwoPieces.size(), 4);
+		}
 	}
 }

--- a/cpp/src/strategies/minmax/tests/BoardEvaluation.cpp
+++ b/cpp/src/strategies/minmax/tests/BoardEvaluation.cpp
@@ -4,22 +4,18 @@
 #include "minmax/config.hpp"
 
 #include <game/Game.hpp>
-#include <game/Board.hpp>
-#include <game/PlacementMove.hpp>
 #include <game/Tile.hpp>
 #include <game/Piece.hpp>
 
+#include "setuphelpers.hpp"
+
 namespace Alphalcazar::Strategy::MinMax {
 	TEST(BoardEvaluation, EvaluateBoard) {
-		Game::Game game {};
-
-		Game::Piece pieceOnePlayerOne { Game::PlayerId::PLAYER_ONE, 1 };
-		Game::Piece pieceFivePlayerOne { Game::PlayerId::PLAYER_ONE, 5 };
-
-		game.GetBoard().GetTile(2, 2)->PlacePiece(pieceOnePlayerOne);
-		game.GetBoard().GetTile(2, 2)->GetPiece()->SetMovementDirection(Game::Direction::NORTH);
-		game.GetBoard().GetTile(1, 1)->PlacePiece(pieceFivePlayerOne);
-		game.GetBoard().GetTile(1, 1)->GetPiece()->SetMovementDirection(Game::Direction::WEST);
+		std::vector<PieceSetup> pieceSetups {
+			{ Game::PlayerId::PLAYER_ONE, 1, Game::Direction::NORTH, { 2, 2 } },
+			{ Game::PlayerId::PLAYER_ONE, 5, Game::Direction::WEST, { 1, 1 } },
+		};
+		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		Score score = EvaluateBoard(Game::PlayerId::PLAYER_ONE, game);
 		Score opponentScore = EvaluateBoard(Game::PlayerId::PLAYER_TWO, game);
@@ -29,28 +25,28 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	TEST(BoardEvaluation, EvaluatePieceLifeTime) {
-		Game::Game perimeterGame {};
-		Game::Piece pieceTwoPerimeter { Game::PlayerId::PLAYER_ONE, 2 };
-		perimeterGame.GetBoard().GetTile(1, 0)->PlacePiece(pieceTwoPerimeter);
-		perimeterGame.GetBoard().GetTile(1, 0)->GetPiece()->SetMovementDirection(Game::Direction::NORTH);
+		std::vector<PieceSetup> perimeterPieceSetups {
+			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 0 } },
+		};
+		Game::Game perimeterGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, perimeterPieceSetups);
 		Score perimeterScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, perimeterGame);
 
-		Game::Game justEnteredGame {};
-		Game::Piece pieceTwoJustEntered { Game::PlayerId::PLAYER_ONE, 2 };
-		justEnteredGame.GetBoard().GetTile(1, 1)->PlacePiece(pieceTwoJustEntered);
-		justEnteredGame.GetBoard().GetTile(1, 1)->GetPiece()->SetMovementDirection(Game::Direction::NORTH);
+		std::vector<PieceSetup> justEnteredPieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 1 } },
+		};
+		Game::Game justEnteredGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, justEnteredPieceSetups);
 		Score justEnteredScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, justEnteredGame);
 
-		Game::Game centerTileGame {};
-		Game::Piece pieceTwoCenterTile { Game::PlayerId::PLAYER_ONE, 2 };
-		centerTileGame.GetBoard().GetTile(1, 2)->PlacePiece(pieceTwoCenterTile);
-		centerTileGame.GetBoard().GetTile(1, 2)->GetPiece()->SetMovementDirection(Game::Direction::NORTH);
+		std::vector<PieceSetup> centerTilePieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 2 } },
+		};
+		Game::Game centerTileGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, centerTilePieceSetups);
 		Score centerTileScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, centerTileGame);
 
-		Game::Game aboutToExitGame {};
-		Game::Piece pieceTwoAboutToExit { Game::PlayerId::PLAYER_ONE, 2 };
-		aboutToExitGame.GetBoard().GetTile(1, 3)->PlacePiece(pieceTwoAboutToExit);
-		aboutToExitGame.GetBoard().GetTile(1, 3)->GetPiece()->SetMovementDirection(Game::Direction::NORTH);
+		std::vector<PieceSetup> aboutToExitPieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 3 } },
+		};
+		Game::Game aboutToExitGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, aboutToExitPieceSetups);
 		Score aboutToExitScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, aboutToExitGame);
 
 		// Pieces on the perimeter don't contribute to score

--- a/cpp/src/strategies/minmax/tests/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/tests/LegalMovements.cpp
@@ -10,6 +10,8 @@
 #include <game/parameters.hpp>
 #include <game/PlacementMove.hpp>
 
+#include "setuphelpers.hpp"
+
 #include <vector>
 
 namespace Alphalcazar::Strategy::MinMax {
@@ -39,11 +41,10 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	TEST(LegalMovements, CornerSymmetries) {
-		Game::Game game {};
-
-		Game::Piece pieceOne { Game::PlayerId::PLAYER_ONE, 1 };
-		game.GetBoard().GetTile(1, 1)->PlacePiece(pieceOne);
-		game.GetBoard().GetTile(1, 1)->GetPiece()->SetMovementDirection(Game::Direction::NORTH);
+		std::vector<PieceSetup> pieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 1, Game::Direction::NORTH, { 1, 1 } },
+		};
+		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		// A single piece on a corner breaks X and Y symmetries
 		auto [xSymmetry, ySymmetry] = GetBoardSymmetries(game);
@@ -52,10 +53,10 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	TEST(LegalMovements, PerimeterSymmetries) {
-		Game::Game game {};
-
-		Game::Piece pieceOne { Game::PlayerId::PLAYER_ONE, 1 };
-		game.GetBoard().PlacePiece({ 4, 2 }, pieceOne, Game::Direction::WEST);
+		std::vector<PieceSetup> pieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 1, Game::Direction::WEST, { 4, 2 } },
+		};
+		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		// The perimeter piece is on the x-axis and faces west, meaning we should still have
 		// x-axis symmetry
@@ -86,10 +87,10 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	TEST(LegalMovements, FilterXAxisSymmetryMovements) {
-		Game::Game game {};
-
-		Game::Piece pieceFour { Game::PlayerId::PLAYER_ONE, 4 };
-		game.GetBoard().PlacePiece({ 2, 1 }, pieceFour, Game::Direction::SOUTH);
+		std::vector<PieceSetup> pieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 4, Game::Direction::SOUTH, { 2, 1 } },
+		};
+		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
 		FilterSymmetricMovements(legalMoves, game);
@@ -106,13 +107,11 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	TEST(LegalMovements, FilterNoSymmetryMovements) {
-		Game::Game game {};
-
-		Game::Piece pieceTwo { Game::PlayerId::PLAYER_ONE, 2 };
-		game.GetBoard().PlacePiece({ 2, 3 }, pieceTwo, Game::Direction::SOUTH);
-
-		Game::Piece pieceFour { Game::PlayerId::PLAYER_ONE, 4 };
-		game.GetBoard().PlacePiece({ 2, 1 }, pieceFour, Game::Direction::EAST);
+		std::vector<PieceSetup> pieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::SOUTH, { 2, 3 } },
+			{ Game::PlayerId::PLAYER_ONE, 4, Game::Direction::EAST, { 2, 1 } },
+		};
+		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE);
 		auto legalMovesSize = legalMoves.size();

--- a/cpp/src/strategies/minmax/tests/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/tests/MinMaxStrategy.cpp
@@ -4,34 +4,14 @@
 #include "minmax/config.hpp"
 
 #include <game/Game.hpp>
-#include <game/Board.hpp>
 #include <game/Tile.hpp>
 #include <game/Piece.hpp>
 #include <game/parameters.hpp>
 #include <game/PlacementMove.hpp>
 
+#include "setuphelpers.hpp"
+
 namespace Alphalcazar::Strategy::MinMax {
-	/// Data structure helper for describing a piece placement on the board
-	struct PieceSetup {
-		Game::PlayerId PlayerId;
-		Game::PieceType PieceType;
-		Game::Direction Direction;
-		Game::Coordinates Coordinates;
-	};
-
-	/// Helper function for quickly configuring a game setup for a MinMax strategy test
-	Game::Game SetupGameForMinMaxTesting(Game::PlayerId playerWithInitiative, bool firstMoveExecuted, const std::vector<PieceSetup>& pieceSetups) {
-		Game::Game game {};
-		game.GetState().FirstMoveExecuted = firstMoveExecuted;
-		game.GetState().PlayerWithInitiative = playerWithInitiative;
-
-		for (auto& pieceSetup : pieceSetups) {
-			Game::Piece piece { pieceSetup.PlayerId, pieceSetup.PieceType };
-			game.GetBoard().PlacePiece(pieceSetup.Coordinates, piece, pieceSetup.Direction);
-		}
-		return game;
-	}
-
 	TEST(MinMaxStrategy, TestWinningSecondMoveDepthOne) {
 		/*
 		 * Player 2 goes second and has the opportunity to immediatelly win the game

--- a/cpp/src/strategies/minmax/tests/setuphelpers.cpp
+++ b/cpp/src/strategies/minmax/tests/setuphelpers.cpp
@@ -1,0 +1,18 @@
+#include "setuphelpers.hpp"
+
+#include <game/Board.hpp>
+#include <game/Piece.hpp>
+
+namespace Alphalcazar::Strategy::MinMax {
+	Game::Game SetupGameForMinMaxTesting(Game::PlayerId playerWithInitiative, bool firstMoveExecuted, const std::vector<PieceSetup>& pieceSetups) {
+		Game::Game game{};
+		game.GetState().FirstMoveExecuted = firstMoveExecuted;
+		game.GetState().PlayerWithInitiative = playerWithInitiative;
+
+		for (auto& pieceSetup : pieceSetups) {
+			Game::Piece piece{ pieceSetup.PlayerId, pieceSetup.PieceType };
+			game.GetBoard().PlacePiece(pieceSetup.Coordinates, piece, pieceSetup.Direction);
+		}
+		return game;
+	}
+}

--- a/cpp/src/strategies/minmax/tests/setuphelpers.hpp
+++ b/cpp/src/strategies/minmax/tests/setuphelpers.hpp
@@ -1,0 +1,15 @@
+#include <game/Game.hpp>
+#include <game/aliases.hpp>
+
+namespace Alphalcazar::Strategy::MinMax {
+	/// Data structure helper for describing a piece placement on the board
+	struct PieceSetup {
+		Game::PlayerId PlayerId;
+		Game::PieceType PieceType;
+		Game::Direction Direction;
+		Game::Coordinates Coordinates;
+	};
+
+	/// Helper function for quickly configuring a game setup for a MinMax strategy test
+	Game::Game SetupGameForMinMaxTesting(Game::PlayerId playerWithInitiative, bool firstMoveExecuted, const std::vector<PieceSetup>& pieceSetups);
+}


### PR DESCRIPTION
Use the smaller `mPlacedPieceCoordinates` cache for piece lookups to speed up the `Board::GetPieces` method.