### PR TITLE
Replace Alphalcazar.Game library exceptions with error logs

### DIFF
--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -28,7 +28,11 @@ namespace Alphalcazar::Game {
 		/// Indicates if the coordinates represent a valid play area tile.
 		bool IsPlayArea() const;
 
-		/// Returns a new Coordinates object representing a movement at a fixed distance in the specified direction
+		/*!
+		 * \brief Returns a new Coordinates object representing a movement at a fixed distance in the specified direction
+		 *
+		 * Returns invalid coordinates if the parameters are invalid (ex. invalid direction).
+		 */
 		Coordinates GetCoordinateInDirection(Direction direction, Coordinate distance) const;
 
 		/*!

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -32,7 +32,7 @@ namespace Alphalcazar::Game {
 				SetPlacedPieceCoordinates(piece, coordinates);
 			}
 		} else {
-			throw "Attempted to place a piece on a non-existing perimeter tile";
+			Utils::LogError("Attempted to place a piece on a non-existing perimeter tile (at {})", coordinates);
 		}
 	}
 
@@ -43,7 +43,7 @@ namespace Alphalcazar::Game {
 
 			SetPlacedPieceCoordinates(piece, coordinates);
 		} else {
-			throw "Attempted to place a piece on a non-existing tile";
+			Utils::LogError("Attempted to place a piece on a non-existing tile (at {})", coordinates);
 		}
 	}
 

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -1,6 +1,8 @@
 #include "game/Coordinates.hpp"
 #include "game/parameters.hpp"
 
+#include <util/Log.hpp>
+
 namespace Alphalcazar::Game {
 	constexpr Coordinate c_InvalidCoordinate = std::numeric_limits<Coordinate>::max();
 
@@ -62,10 +64,12 @@ namespace Alphalcazar::Game {
 
 	Coordinates Coordinates::GetCoordinateInDirection(Direction direction, Coordinate distance) const {
 		if (!Valid()) {
-			throw "Tried to get coordinate offset from an invalid coordinate";
+			Utils::LogError("Tried to get coordinate offset from an invalid coordinate");
+			return Invalid();
 		}
 		if (direction == Direction::NONE) {
-			throw "Tried getting a coordinate offset into an invalid direction";
+			Utils::LogError("Tried getting a coordinate offset into an invalid direction");
+			return Invalid();
 		}
 
 		Coordinates& offset = c_DirectionOffsets.at(direction);

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -6,6 +6,8 @@
 #include "game/Strategy.hpp"
 #include "game/Piece.hpp"
 
+#include <util/Log.hpp>
+
 namespace Alphalcazar::Game {
 	Game::Game() {}
 
@@ -70,11 +72,13 @@ namespace Alphalcazar::Game {
 		// If a player has no available legal moves, their turn is skipped
 		if (legalMoves.size() > 0) {
 			PlacementMoveIndex placementMoveIndex = strategy.Execute(playerId, legalMoves, *this);
-			if (placementMoveIndex < 0 || placementMoveIndex >= legalMoves.size()) {
-				throw "Invalid legal move index returned by player strategy";
+			if (placementMoveIndex >= 0 && placementMoveIndex < legalMoves.size()) {
+				auto& placementMove = legalMoves[placementMoveIndex];
+				ExecutePlacementMove(playerId, placementMove);
+			} else {
+				Utils::LogError("Invalid legal move index ({}) returned by player strategy", placementMoveIndex);
 			}
-			auto& placementMove = legalMoves[placementMoveIndex];
-			ExecutePlacementMove(playerId, placementMove);
+
 		}
 	}
 

--- a/cpp/src/game/src/game/Tile.cpp
+++ b/cpp/src/game/src/game/Tile.cpp
@@ -1,5 +1,6 @@
 #include "game/Piece.hpp"
 #include "game/Tile.hpp"
+#include <util/Log.hpp>
 
 namespace Alphalcazar::Game {
 	Tile::Tile() {}
@@ -17,7 +18,7 @@ namespace Alphalcazar::Game {
 
 	void Tile::PlacePiece(const Piece& piece) {
 		if (mPiece.IsValid()) {
-			throw "Tried placing a piece on a tile that already had a piece on it.";
+			Utils::LogError("Tried placing a piece on a tile that already had a piece on it.");
 		}
 		mPiece = piece;
 	}


### PR DESCRIPTION
The `Alphalcazar.Game` library shouldn't throw exceptions, that's just bad API design.