### PR TITLE
Replace heuristic score multiplier map with logical operations on the coordinates

### DIFF
--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -23,10 +23,14 @@ namespace Alphalcazar::Game {
 
 		/// Indicates if the coordinates represent a position in the perimeter of the board
 		bool IsPerimeter() const;
-		/// Indicates if the coordinates represent a corner of the board. No tile will exist at these coordinates.
+		/// Indicates if the coordinates represent a corner of the play area. No tile will exist at these coordinates.
 		bool IsCorner() const;
 		/// Indicates if the coordinates represent a valid play area tile.
 		bool IsPlayArea() const;
+		/// Indicates if the coordinates represent the center of the boared
+		bool IsCenter() const;
+		/// Indicates if the coordinates represent a corner of the board
+		bool IsBoardCorner() const;
 
 		/*!
 		 * \brief Returns a new Coordinates object representing a movement at a fixed distance in the specified direction
@@ -61,20 +65,6 @@ namespace std {
 			auto xHash = hash<Alphalcazar::Game::Coordinate>()(coordinates.x);
 			auto yHash = hash<Alphalcazar::Game::Coordinate>()(coordinates.y);
 			return ((xHash ^ (yHash << 1)) >> 1);
-		}
-	};
-
-	/*
-	* We also implement a hashing function for pairs of Coordinates with any other hashable type.
-	* This will be useful for using pairs of Coordinates with other types (like \ref Direction) as keys
-	* for unordered maps.
-	*/
-	template <class T> 
-	struct hash<std::pair<Alphalcazar::Game::Coordinates, T>> {
-		std::size_t operator()(const std::pair<Alphalcazar::Game::Coordinates, Alphalcazar::Game::Direction>& pair) const noexcept {
-			auto coordinatesHash = hash<Alphalcazar::Game::Coordinates>()(pair.first);
-			auto pairedValueHash = hash<T>()(pair.second);
-			return ((coordinatesHash ^ (pairedValueHash << 1)) >> 1);
 		}
 	};
 }

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -42,8 +42,16 @@ namespace Alphalcazar::Game {
 		return x == 0 || x == c_PlayAreaSize - 1 || y == 0 || y == c_PlayAreaSize - 1;
 	}
 
+	bool Coordinates::IsCenter() const {
+		return x == c_CenterCoordinate && y == c_CenterCoordinate;
+	}
+
 	bool Coordinates::IsCorner() const {
 		return (x == 0 || x == c_PlayAreaSize - 1) && (y == 0 || y == c_PlayAreaSize - 1);
+	}
+
+	bool Coordinates::IsBoardCorner() const {
+		return (x == 1 || x == c_BoardSize) && (y == 1 || y == c_BoardSize);
 	}
 
 	Direction Coordinates::GetLegalPlacementDirection() const {

--- a/cpp/src/strategies/minmax/include/minmax/BoardEvaluation.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/BoardEvaluation.hpp
@@ -8,7 +8,29 @@ namespace Alphalcazar::Game {
 }
 
 namespace Alphalcazar::Strategy::MinMax {
+	/// Converts a game result to a score.
 	Score GameResultToScore(Game::PlayerId playerId, Game::GameResult result);
+
+	/*!
+	 * \brief Evaluates the board of a given game and returns a heuristic score for the specified player.
+	 * 
+	 * \param playerId The ID of the player for which the score is being calculated.
+	 * \param game The game to evaluate.
+	 * 
+	 * \note The function has player symmetry, meaning that if the score of a game for a player is X, the score
+	 *       of the same game for the opponent will be -X.
+	 */
 	Score EvaluateBoard(Game::PlayerId playerId, const Game::Game& game);
-	Score GetDepthAdjustedScore(Score score);
+
+	/*!
+	 * \brief Adjusts a given score for a given depth level.
+	 * 
+	 * The absolute value of the score will be reduced (moved closer to 0) in order to
+	 * ensure that if several moves lead to the same position/result, the heuristic advantage/disadvantage
+	 * is reduced for longer paths and maximized for immediate paths.
+	 *
+	 * \param score The original score before adjusting for depth.
+	 * \param depth The depth level for which to adjust the score
+	 */
+	Score GetDepthAdjustedScore(Score score, Depth depth);
 }

--- a/cpp/src/strategies/minmax/include/minmax/config.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/config.hpp
@@ -5,7 +5,6 @@
 #include "game/Coordinates.hpp"
 
 #include <array>
-#include <unordered_map>
 
 namespace Alphalcazar::Strategy::MinMax {
 	/*!
@@ -14,11 +13,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	 *
 	 * \note A loss will be represented with the negated win condition score.
 	 */
-	static constexpr Score c_WinConditionScore = 1000;
-	/// The initial value of the "alpha" parameter of the minmax algorithm
-	static constexpr Score c_AlphaStartingValue = -c_WinConditionScore * 10;
-	/// The initial value of the "beta" parameter of the minmax algorithm
-	static constexpr Score c_BetaStartingValue = c_WinConditionScore * 10;
+	constexpr Score c_WinConditionScore = 1000;
 	/*!
 	 * \brief A penalty that will be subtracted from a movement's score each movement for each level of depth.
 	 *
@@ -29,9 +24,9 @@ namespace Alphalcazar::Strategy::MinMax {
 	 * \note The value of this penalty should be low enough to never have an impact on the score appart
 	 * from deciding between moves with equal score but different depth.
 	 */
-	static constexpr Score c_DepthScorePenalty = 1;
+	constexpr Score c_DepthScorePenalty = 1;
 
-	static constexpr std::array<Score, Game::c_PieceTypes> c_PieceOnBoardScores{{
+	constexpr std::array<Score, Game::c_PieceTypes> c_PieceOnBoardScores{{
 		80, // Piece 1
 		120, // Piece 2
 		140, // Piece 3
@@ -39,66 +34,9 @@ namespace Alphalcazar::Strategy::MinMax {
 		100 // Piece 5
 	}};
 
-	static constexpr float c_CenterPieceMultiplier = 2.f;
-	static constexpr float c_FreshCornerPieceMultiplier = 1.55f;
-	static constexpr float c_FreshCenterLanePieceMultiplier = 1.7f;
-	static constexpr float c_PieceAboutToExitMultiplier = 0.7f;
-	static constexpr float c_LateralCenterLanePieceMultiplier = 1.f;
-
-	/*!
-	 * \brief A map of score multipliers in relation to all combinations of coordinates and piece directions.
-	 *
-	 * The multipliers of this map will be multiplied with the piece score of each piece on the board when evaluating a total board score.
-	 * The general idea is to give higher score values to pieces that have strategic locations (like the center) or have a long expected
-	 * lifespan (just entered the board and have 3 movements ahead), and lower scores to pieces that are about to exit the board.
-	 */
-	static std::unordered_map<std::pair<Game::Coordinates, Game::Direction>, float> c_CoordinatesScoreMultiplier {
-		// Center
-		{ { { 2, 2 }, Game::Direction::NORTH }, c_CenterPieceMultiplier },
-		{ { { 2, 2 }, Game::Direction::SOUTH }, c_CenterPieceMultiplier },
-		{ { { 2, 2 }, Game::Direction::EAST }, c_CenterPieceMultiplier },
-		{ { { 2, 2 }, Game::Direction::WEST }, c_CenterPieceMultiplier },
-
-		// Corners
-		{ { { 1, 1 }, Game::Direction::NORTH }, c_FreshCornerPieceMultiplier },
-		{ { { 1, 1 }, Game::Direction::SOUTH }, c_PieceAboutToExitMultiplier },
-		{ { { 1, 1 }, Game::Direction::EAST }, c_FreshCornerPieceMultiplier },
-		{ { { 1, 1 }, Game::Direction::WEST }, c_PieceAboutToExitMultiplier },
-
-		{ { { 1, 3 }, Game::Direction::NORTH }, c_PieceAboutToExitMultiplier },
-		{ { { 1, 3 }, Game::Direction::SOUTH }, c_FreshCornerPieceMultiplier },
-		{ { { 1, 3 }, Game::Direction::EAST }, c_FreshCornerPieceMultiplier },
-		{ { { 1, 3 }, Game::Direction::WEST }, c_PieceAboutToExitMultiplier },
-
-		{ { { 3, 1 }, Game::Direction::NORTH }, c_FreshCornerPieceMultiplier },
-		{ { { 3, 1 }, Game::Direction::SOUTH }, c_PieceAboutToExitMultiplier },
-		{ { { 3, 1 }, Game::Direction::EAST }, c_PieceAboutToExitMultiplier },
-		{ { { 3, 1 }, Game::Direction::WEST }, c_FreshCornerPieceMultiplier },
-
-		{ { { 3, 3 }, Game::Direction::NORTH }, c_PieceAboutToExitMultiplier },
-		{ { { 3, 3 }, Game::Direction::SOUTH }, c_FreshCornerPieceMultiplier },
-		{ { { 3, 3 }, Game::Direction::EAST }, c_PieceAboutToExitMultiplier },
-		{ { { 3, 3 }, Game::Direction::WEST }, c_FreshCornerPieceMultiplier },
-
-		// Lane centers
-		{ { { 1, 2 }, Game::Direction::NORTH }, c_LateralCenterLanePieceMultiplier },
-		{ { { 1, 2 }, Game::Direction::SOUTH }, c_LateralCenterLanePieceMultiplier },
-		{ { { 1, 2 }, Game::Direction::EAST }, c_FreshCenterLanePieceMultiplier },
-		{ { { 1, 2 }, Game::Direction::WEST }, c_PieceAboutToExitMultiplier },
-
-		{ { { 2, 1 }, Game::Direction::NORTH }, c_FreshCenterLanePieceMultiplier },
-		{ { { 2, 1 }, Game::Direction::SOUTH }, c_PieceAboutToExitMultiplier },
-		{ { { 2, 1 }, Game::Direction::EAST }, c_LateralCenterLanePieceMultiplier },
-		{ { { 2, 1 }, Game::Direction::WEST }, c_LateralCenterLanePieceMultiplier },
-
-		{ { { 2, 3 }, Game::Direction::NORTH }, c_PieceAboutToExitMultiplier },
-		{ { { 2, 3 }, Game::Direction::SOUTH }, c_FreshCenterLanePieceMultiplier },
-		{ { { 2, 3 }, Game::Direction::EAST }, c_LateralCenterLanePieceMultiplier },
-		{ { { 2, 3 }, Game::Direction::WEST }, c_LateralCenterLanePieceMultiplier },
-
-		{ { { 3, 2 }, Game::Direction::NORTH }, c_LateralCenterLanePieceMultiplier },
-		{ { { 3, 2 }, Game::Direction::SOUTH }, c_LateralCenterLanePieceMultiplier },
-		{ { { 3, 2 }, Game::Direction::EAST }, c_PieceAboutToExitMultiplier },
-		{ { { 3, 2 }, Game::Direction::WEST }, c_FreshCenterLanePieceMultiplier }
-	};
+	constexpr float c_CenterPieceMultiplier = 2.f;
+	constexpr float c_FreshCornerPieceMultiplier = 1.55f;
+	constexpr float c_FreshCenterLanePieceMultiplier = 1.7f;
+	constexpr float c_PieceAboutToExitMultiplier = 0.7f;
+	constexpr float c_LateralCenterLanePieceMultiplier = 1.f;
 }

--- a/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
@@ -6,6 +6,39 @@
 #include <algorithm>
 
 namespace Alphalcazar::Strategy::MinMax {
+	/*!
+	 * \brief Returns a score multiplier for the heuristic score of a piece given its position and direction on the board.
+	 *
+	 * Grants a higher multiplier for pieces that are well positioned (ex. in the center) or have a long expected
+	 * lifetime (ex. facing towards the board interior) and a lower multiplier for pieces that are badly positioned or
+	 * with a short expected lifetime (ex. about to exit the board).
+	 */
+	float GetPieceScoreMultiplier(const Game::Coordinates& coordinates, Game::Direction direction) {
+		if (coordinates.IsCenter()) {
+			return c_CenterPieceMultiplier;
+		} else if (coordinates.IsBoardCorner()) {
+			// In the board corners, a piece can only have recently entered the board
+			// or be about to leave it
+			auto pieceTargetCoordinate = coordinates.GetCoordinateInDirection(direction, 1);
+			if (pieceTargetCoordinate.IsPerimeter()) {
+				return c_PieceAboutToExitMultiplier;
+			} else {
+				return c_FreshCornerPieceMultiplier;
+			}
+		} else {
+			// The piece is on one of the center lanes, but not in the center tile
+			auto pieceTargetCoordinate = coordinates.GetCoordinateInDirection(direction, 1);
+			if (pieceTargetCoordinate.IsPerimeter()) {
+				// The piece is about to exit the board
+				return c_PieceAboutToExitMultiplier;
+			} else if (pieceTargetCoordinate.IsCenter()) {
+				// The piece just entered the center lane and wants to move to the center
+				return c_FreshCenterLanePieceMultiplier;
+			}
+		}
+		return 1.f;
+	}
+
 	Score GameResultToScore(Game::PlayerId playerId, Game::GameResult result) {
 		switch (result) {
 		case Game::GameResult::PLAYER_ONE_WINS:
@@ -25,11 +58,12 @@ namespace Alphalcazar::Strategy::MinMax {
 		for (auto& [coordinates, piece] : pieces) {
 			if (!coordinates.IsPerimeter()) {
 				auto direction = piece.GetMovementDirection();
-				float coordinatesScoreMultiplier = c_CoordinatesScoreMultiplier.at(std::make_pair(coordinates, direction));
+				float pieceScoreMultiplier = GetPieceScoreMultiplier(coordinates, direction);
+
 				// The piece on board score array stores all piece types in order, meaning that
 				// the score of a certain piece type will be located at index (type - 1)
 				Score pieceOnBoardScore = c_PieceOnBoardScores[piece.GetType() - 1];
-				Score pieceScore = static_cast<Score>(pieceOnBoardScore * coordinatesScoreMultiplier);
+				Score pieceScore = static_cast<Score>(pieceOnBoardScore * pieceScoreMultiplier);
 
 				// Add the score if the piece belongs to the player for which we are evaluating the score
 				// or subtract it if it belongs to the opponent
@@ -44,8 +78,9 @@ namespace Alphalcazar::Strategy::MinMax {
 		return totalScore;
 	}
 
-	Score GetDepthAdjustedScore(Score score) {
-		Score penalty = std::min(c_DepthScorePenalty, static_cast<Score>(std::abs(score)));
+	Score GetDepthAdjustedScore(Score score, Depth depth) {
+		Score depthPenalty = depth * c_DepthScorePenalty;
+		Score penalty = std::min(depthPenalty, static_cast<Score>(std::abs(score)));
 		if (score > 0) {
 			score -= penalty;
 		} else {

--- a/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
@@ -9,6 +9,11 @@
 #include <util/Log.hpp>
 
 namespace Alphalcazar::Strategy::MinMax {
+	/// The initial value of the "alpha" parameter of the minmax algorithm
+	constexpr Score c_AlphaStartingValue = -c_WinConditionScore * 10;
+	/// The initial value of the "beta" parameter of the minmax algorithm
+	constexpr Score c_BetaStartingValue = c_WinConditionScore * 10;
+
 	MinMaxStrategy::MinMaxStrategy(const Depth depth)
 		: mDepth { depth }
 	{}
@@ -91,9 +96,10 @@ namespace Alphalcazar::Strategy::MinMax {
 				nextBestScore = Min(playerId, nextDepth, gameCopy, alpha, beta);
 			}
 			// If we decreased the depth when calculating the next move score
-			// we add a depth penalty
+			// we add a depth penalty. Since this function is called recursively, we only
+			// adjust for 1 depth level at a time.
 			if (nextDepth < depth) {
-				nextBestScore = GetDepthAdjustedScore(nextBestScore);
+				nextBestScore = GetDepthAdjustedScore(nextBestScore, 1);
 			}
 		}
 		return nextBestScore;


### PR DESCRIPTION
Does not affect performance significantly but makes following the logic of how heuristic piece score multipliers work much easier.

Benchmarks before:

```
[2022-06-28 20:56:51.843] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-06-28 20:56:51.932] [info] First move at depth 2 took 87ms and calculated a score of -34
[2022-06-28 20:57:14.072] [info] First move at depth 3 took 22139ms and calculated a score of 0
```

After:
```
[2022-06-28 20:59:15.491] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-06-28 20:59:15.580] [info] First move at depth 2 took 87ms and calculated a score of -34
[2022-06-28 20:59:36.034] [info] First move at depth 3 took 20453ms and calculated a score of 0
```