### PR TITLE
Sort legal moves by heuristic scores

### DIFF
--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -20,6 +20,7 @@ namespace Alphalcazar::Game {
 		~Coordinates();
 
 		bool operator==(const Coordinates& coord) const;
+		bool operator!=(const Coordinates& coord) const;
 
 		/// Indicates if the coordinates represent a position in the perimeter of the board
 		bool IsPerimeter() const;
@@ -27,8 +28,10 @@ namespace Alphalcazar::Game {
 		bool IsCorner() const;
 		/// Indicates if the coordinates represent a valid play area tile.
 		bool IsPlayArea() const;
-		/// Indicates if the coordinates represent the center of the boared
+		/// Indicates if the coordinates represent the center of the board
 		bool IsCenter() const;
+		/// Indicates if the coordinates represent a tile that is on either the row or column that contains the center tile of the board
+		bool IsOnCenterLane() const;
 		/// Indicates if the coordinates represent a corner of the board
 		bool IsBoardCorner() const;
 

--- a/cpp/src/game/include/game/Strategy.hpp
+++ b/cpp/src/game/include/game/Strategy.hpp
@@ -19,15 +19,15 @@ namespace Alphalcazar::Game {
 		virtual ~Strategy() = default;
 
 		/*!
-		 * \brief Returns the placement move index to execute given the state of the game 
+		 * \brief Returns the placement move to execute given the state of the game 
 		          and the player who executes the strategy.
 	     *
 		 * \param playerId The ID of the player who's turn it is to play.
 		 * \param legalMoves The list of available legal moves the player currently has available.
 		 * \param game The game object. Can be used to factor in the state of the game and the board in order to chose a move.
 		 * 
-		 * \returns The index of the move (in the legalMoves parameter) of the move to be executed.
+		 * \returns The move to be executed.
 		 */
-		virtual PlacementMoveIndex Execute(PlayerId playerId, const std::vector<PlacementMove>& legalMoves, const Game& game) = 0;
+		virtual PlacementMove Execute(PlayerId playerId, const std::vector<PlacementMove>& legalMoves, const Game& game) = 0;
 	};
 }

--- a/cpp/src/game/include/game/aliases.hpp
+++ b/cpp/src/game/include/game/aliases.hpp
@@ -7,7 +7,6 @@ namespace Alphalcazar::Game {
 	using PieceType = std::uint8_t;
 	constexpr PieceType c_InvalidPieceType = 0;
 	using Coordinate = std::int8_t; // (+-128 should be more than enough for a 3x3 board)
-	using PlacementMoveIndex = std::uint8_t;
 
 	enum class GameResult {
 		NONE = 0,

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -89,7 +89,7 @@ namespace Alphalcazar::Game {
 		}
 
 		Coordinates& offset = c_DirectionOffsets.at(direction);
-		return Coordinates{ x + offset.x * distance, y + offset.y * distance };
+		return Coordinates(x + offset.x * distance, y + offset.y * distance);
 	}
 
 	bool Coordinates::Valid() const {
@@ -97,6 +97,6 @@ namespace Alphalcazar::Game {
 	}
 
 	Coordinates Coordinates::Invalid() {
-		return Coordinates{ c_InvalidCoordinate, c_InvalidCoordinate };
+		return Coordinates { c_InvalidCoordinate, c_InvalidCoordinate };
 	}
 }

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -89,7 +89,7 @@ namespace Alphalcazar::Game {
 		}
 
 		Coordinates& offset = c_DirectionOffsets.at(direction);
-		return { x + offset.x * distance, y + offset.y * distance };
+		return Coordinates{ x + offset.x * distance, y + offset.y * distance };
 	}
 
 	bool Coordinates::Valid() const {
@@ -97,6 +97,6 @@ namespace Alphalcazar::Game {
 	}
 
 	Coordinates Coordinates::Invalid() {
-		return { c_InvalidCoordinate, c_InvalidCoordinate };
+		return Coordinates{ c_InvalidCoordinate, c_InvalidCoordinate };
 	}
 }

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -34,6 +34,10 @@ namespace Alphalcazar::Game {
 		return x == coord.x && y == coord.y;
 	}
 
+	bool Coordinates::operator!=(const Coordinates& coord) const {
+		return x != coord.x || y != coord.y;
+	}
+
 	bool Coordinates::IsPlayArea() const {
 		return x >= 0 && x < c_PlayAreaSize&& y >= 0 && y < c_PlayAreaSize && !IsCorner();
 	}
@@ -44,6 +48,10 @@ namespace Alphalcazar::Game {
 
 	bool Coordinates::IsCenter() const {
 		return x == c_CenterCoordinate && y == c_CenterCoordinate;
+	}
+
+	bool Coordinates::IsOnCenterLane() const {
+		return x == c_CenterCoordinate || y == c_CenterCoordinate;
 	}
 
 	bool Coordinates::IsCorner() const {
@@ -81,7 +89,7 @@ namespace Alphalcazar::Game {
 		}
 
 		Coordinates& offset = c_DirectionOffsets.at(direction);
-		return Coordinates(x + offset.x * distance, y + offset.y * distance);
+		return { x + offset.x * distance, y + offset.y * distance };
 	}
 
 	bool Coordinates::Valid() const {
@@ -89,6 +97,6 @@ namespace Alphalcazar::Game {
 	}
 
 	Coordinates Coordinates::Invalid() {
-		return Coordinates { c_InvalidCoordinate, c_InvalidCoordinate };
+		return { c_InvalidCoordinate, c_InvalidCoordinate };
 	}
 }

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -71,14 +71,8 @@ namespace Alphalcazar::Game {
 		auto legalMoves = GetLegalMoves(playerId);
 		// If a player has no available legal moves, their turn is skipped
 		if (legalMoves.size() > 0) {
-			PlacementMoveIndex placementMoveIndex = strategy.Execute(playerId, legalMoves, *this);
-			if (placementMoveIndex >= 0 && placementMoveIndex < legalMoves.size()) {
-				auto& placementMove = legalMoves[placementMoveIndex];
-				ExecutePlacementMove(playerId, placementMove);
-			} else {
-				Utils::LogError("Invalid legal move index ({}) returned by player strategy", placementMoveIndex);
-			}
-
+			auto placementMove = strategy.Execute(playerId, legalMoves, *this);
+			ExecutePlacementMove(playerId, placementMove);
 		}
 	}
 

--- a/cpp/src/main/main.cpp
+++ b/cpp/src/main/main.cpp
@@ -14,7 +14,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
 		Alphalcazar::Strategy::MinMax::MinMaxStrategy strategy { depth };
 		Alphalcazar::Game::Game game {};
 		auto gameStart = std::chrono::high_resolution_clock::now();
-		game.Play(strategy, strategy);
+		// auto result = game.Play(strategy, strategy);
 		strategy.Execute(Alphalcazar::Game::PlayerId::PLAYER_ONE, game.GetLegalMoves(Alphalcazar::Game::PlayerId::PLAYER_ONE), game);
 		auto score = strategy.GetLastExecutedMoveScore();
 		auto gameEnd = std::chrono::high_resolution_clock::now();

--- a/cpp/src/main/main.cpp
+++ b/cpp/src/main/main.cpp
@@ -14,7 +14,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
 		Alphalcazar::Strategy::MinMax::MinMaxStrategy strategy { depth };
 		Alphalcazar::Game::Game game {};
 		auto gameStart = std::chrono::high_resolution_clock::now();
-		// auto result = game.Play(strategy, strategy);
+		game.Play(strategy, strategy);
 		strategy.Execute(Alphalcazar::Game::PlayerId::PLAYER_ONE, game.GetLegalMoves(Alphalcazar::Game::PlayerId::PLAYER_ONE), game);
 		auto score = strategy.GetLastExecutedMoveScore();
 		auto gameEnd = std::chrono::high_resolution_clock::now();

--- a/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
@@ -7,19 +7,42 @@
 #include <tuple>
 
 namespace Alphalcazar::Game {
-	class Game;
+	class Board;
 	struct PlacementMove;
 }
 
 namespace Alphalcazar::Strategy::MinMax {
 	/*!
-	 * \brief Calculates the symmetry axes of the board of a given game.
+	 * \brief Calculates the symmetry axes of the board of a given board.
 	 *
-	 * A board of this game can only have x-axis or y-axis symmetry, as pieces can only move along these axis. Pieces cannot
+	 * A board can only have x-axis or y-axis symmetry, as pieces can only move along these axis. Pieces cannot
 	 * have directions like south-west or north-east, making diagonal symmetries impossible.
 	 *
 	 * \returns A pair with 2 boolean values, the first being the x-axis symmetry of the board and the second the y-axis symmetry.
 	 */
-	std::pair<bool, bool> GetBoardSymmetries(const Game::Game& game);
-	void FilterSymmetricMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game);
+	std::pair<bool, bool> GetBoardSymmetries(const Game::Board& board);
+
+	/*!
+	 * \brief Filters a list of legal movements, erasing those that are duplicated once board
+	 *        symmetries are taken into account.
+	 * 
+	 * This means that if several moves would cause the resulting board states to be identical with some symmetry
+	 * (ex. x-axis symmetry), only one of those moves (the first one) is kept in the list.
+	 * 
+	 * \param legalMoves The list of legal moves to filter. Will potentially be modified.
+	 * \param board The board of the game for which the legal movements are valid.
+	 */
+	void FilterSymmetricMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board);
+
+	/*!
+	 * \brief Sorts a list of legal movements by the heuristic score we expect to obtain from playing
+	 *        each of those movements.
+	 * 
+	 * Alpha-beta-pruning algorithms are most efficient when the best moves are explored first. Since this is
+	 * not possible until the branch is actually explore, we use this heuristic to try to approximate it.
+	 * 
+	 * \param legalMoves The list of legal moves to sort. Will potentially be modified.
+	 * \param board The board of the game for which the legal movements are valid.
+	 */
+	void SortLegalMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board);
 }

--- a/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
@@ -20,7 +20,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	class MinMaxStrategy final : public Game::Strategy {
 	public:
 		MinMaxStrategy(const Depth depth);
-		virtual Game::PlacementMoveIndex Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) override;
+		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) override;
 		Score GetLastExecutedMoveScore() const;
 	private:
 		Score Max(Game::PlayerId playerId, Depth depth, const Game::Game& game, Score alpha, Score beta);

--- a/cpp/src/strategies/minmax/include/minmax/config.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/config.hpp
@@ -39,4 +39,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	constexpr float c_FreshCenterLanePieceMultiplier = 1.7f;
 	constexpr float c_PieceAboutToExitMultiplier = 0.7f;
 	constexpr float c_LateralCenterLanePieceMultiplier = 1.f;
+
+	constexpr Score c_CenterLanePieceMultiplier = 2;
+	constexpr Score c_LateralLanePieceMultiplier = 1;
 }

--- a/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
@@ -73,7 +73,6 @@ namespace Alphalcazar::Strategy::MinMax {
 					totalScore -= pieceScore;
 				}
 			}
-
 		}
 		return totalScore;
 	}

--- a/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
@@ -1,17 +1,21 @@
 #include "minmax/LegalMovements.hpp"
 #include "minmax/config.hpp"
 
-#include <game/Game.hpp>
+#include <game/Board.hpp>
 #include <game/Piece.hpp>
 #include <game/parameters.hpp>
 #include <game/Coordinates.hpp>
 #include <game/PlacementMove.hpp>
 
+#include <util/Log.hpp>
+
+#include <algorithm>
+
 namespace Alphalcazar::Strategy::MinMax {
-	std::pair<bool, bool> GetBoardSymmetries(const Game::Game& game) {
+	std::pair<bool, bool> GetBoardSymmetries(const Game::Board& board) {
 		bool xSymmetry = true;
 		bool ySymmetry = true;
-		for (auto& [coordinates, piece] : game.GetBoard().GetPieces()) {
+		for (auto& [coordinates, piece] : board.GetPieces()) {
 			auto direction = piece.GetMovementDirection();
 			if (coordinates.y != Game::c_CenterCoordinate || direction == Game::Direction::NORTH || direction == Game::Direction::SOUTH) {
 				// x-axis symmetry can only exist if all pieces (including perimeter ones) are placed along the horizontal center row
@@ -32,8 +36,8 @@ namespace Alphalcazar::Strategy::MinMax {
 		return std::make_pair(xSymmetry, ySymmetry);
 	}
 
-	void FilterSymmetricMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) {
-		auto symmetries = GetBoardSymmetries(game);
+	void FilterSymmetricMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board) {
+		auto symmetries = GetBoardSymmetries(board);
 		bool xSymmetry = symmetries.first;
 		bool ySymmetry = symmetries.second;
 
@@ -58,5 +62,48 @@ namespace Alphalcazar::Strategy::MinMax {
 			),
 			legalMoves.end()
 		);
+	}
+
+	/// Returns an heuristic approximation of the score we expect to gain from a given placement move, for sorting purposes
+	Score GetHeuristicPlacementMoveScore(const Game::PlacementMove& move, const Game::Board& board) {
+		// First, we check if we have good reason to believe that the movement would result in the placed
+		// piece not even entering the board. While this can be beneficial in some very specific situations,
+		// most times it would just be a blunder, so it makes sense to assign these movements the lowest score
+		if (move.PieceType != Game::c_PusherPieceType) {
+			if (auto* moveTile = board.GetTile(move.Coordinates)) {
+				auto placementDirection = moveTile->GetLegalPlacementDirection();
+				auto pieceTargetCoordinate = move.Coordinates.GetCoordinateInDirection(placementDirection, 1);
+				if (auto* pieceTargetTilePiece = board.GetTile(pieceTargetCoordinate)->GetPiece()) {
+					// There's a piece on the tile that our piece is looking at
+					// We check if we can expect the piece to be gone before our piece moves
+					// or if the piece can be pushed by us
+					if (!pieceTargetTilePiece->IsPushable()) {
+						auto blockingPieceTargetCoordinate = pieceTargetCoordinate.GetCoordinateInDirection(pieceTargetTilePiece->GetMovementDirection(), 1);
+						// We check if the target piece moves after us, or if it will attempt to move to the position where we have placed
+						// the piece, causing its movement to be blocked
+						if (pieceTargetTilePiece->GetType() > move.PieceType || blockingPieceTargetCoordinate == move.Coordinates) {
+							return 0;
+						}
+					}
+				}
+			} else {
+				Utils::LogError("Legal move pointed at {}, but no board tile was found at those coordinates.", move.Coordinates);
+			}
+		}
+
+		// Once we assume that the piece will be able to enter the board, we assign a score based on the piece type and target row
+		Score expectedPieceScore = c_PieceOnBoardScores[move.PieceType - 1];
+		if (move.Coordinates.IsOnCenterLane()) {
+			return expectedPieceScore * c_CenterLanePieceMultiplier;
+		} else {
+			return expectedPieceScore * c_LateralLanePieceMultiplier;
+		}
+	}
+
+	void SortLegalMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board) {
+		std::sort(legalMoves.begin(), legalMoves.end(), [board](const Game::PlacementMove& moveA, const Game::PlacementMove& moveB) {
+			// Sort the vector by the heuristic score of the placement moves
+			return GetHeuristicPlacementMoveScore(moveA, board) > GetHeuristicPlacementMoveScore(moveB, board);
+		});
 	}
 }

--- a/cpp/src/strategies/minmax/tests/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/tests/LegalMovements.cpp
@@ -19,7 +19,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		Game::Game game {};
 
 		// An empty board should have both X and Y symmetry
-		auto [xSymmetryEmpty, ySymmetryEmpty] = GetBoardSymmetries(game);
+		auto [xSymmetryEmpty, ySymmetryEmpty] = GetBoardSymmetries(game.GetBoard());
 		EXPECT_TRUE(xSymmetryEmpty);
 		EXPECT_TRUE(ySymmetryEmpty);
 
@@ -27,7 +27,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		game.GetBoard().PlacePiece({ 2, 2 }, pieceOne, Game::Direction::NORTH);
 
 		// A piece in the center pointing north should create Y symmetry
-		auto [xSymmetryCenterPiece, ySymmetryCenterPiece] = GetBoardSymmetries(game);
+		auto [xSymmetryCenterPiece, ySymmetryCenterPiece] = GetBoardSymmetries(game.GetBoard());
 		EXPECT_FALSE(xSymmetryCenterPiece);
 		EXPECT_TRUE(ySymmetryCenterPiece);
 
@@ -35,7 +35,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		game.GetBoard().PlacePiece({ 2, 3 }, pieceTwo, Game::Direction::EAST);
 
 		// Once we have added a second piece, still in the center row but facing east, all symmetries should be broken
-		auto [xSymmetryTwoPieces, ySymmetryTwoPieces] = GetBoardSymmetries(game);
+		auto [xSymmetryTwoPieces, ySymmetryTwoPieces] = GetBoardSymmetries(game.GetBoard());
 		EXPECT_FALSE(xSymmetryTwoPieces);
 		EXPECT_FALSE(ySymmetryTwoPieces);
 	}
@@ -47,7 +47,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		// A single piece on a corner breaks X and Y symmetries
-		auto [xSymmetry, ySymmetry] = GetBoardSymmetries(game);
+		auto [xSymmetry, ySymmetry] = GetBoardSymmetries(game.GetBoard());
 		EXPECT_FALSE(xSymmetry);
 		EXPECT_FALSE(ySymmetry);
 	}
@@ -60,7 +60,7 @@ namespace Alphalcazar::Strategy::MinMax {
 
 		// The perimeter piece is on the x-axis and faces west, meaning we should still have
 		// x-axis symmetry
-		auto [xSymmetry, ySymmetry] = GetBoardSymmetries(game);
+		auto [xSymmetry, ySymmetry] = GetBoardSymmetries(game.GetBoard());
 		EXPECT_TRUE(xSymmetry);
 		EXPECT_FALSE(ySymmetry);
 
@@ -69,7 +69,7 @@ namespace Alphalcazar::Strategy::MinMax {
 
 		// After placing a second piece (which on its own would still make the board have x-axis symmetry)
 		// we check that the combination of both pieces breaks both symmetries, each piece breaking 1 axis.
-		auto [xSymmetryTwoPieces, ySymmetryTwoPieces] = GetBoardSymmetries(game);
+		auto [xSymmetryTwoPieces, ySymmetryTwoPieces] = GetBoardSymmetries(game.GetBoard());
 		EXPECT_FALSE(xSymmetryTwoPieces);
 		EXPECT_FALSE(ySymmetryTwoPieces);
 	}
@@ -80,7 +80,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		// On an empty board, all combinations of piece type and perimeter tile should create a legal move
 		EXPECT_EQ(legalMoves.size(), Game::c_PieceTypes * game.GetBoard().GetPerimeterTiles().size());
 
-		FilterSymmetricMovements(legalMoves, game);
+		FilterSymmetricMovements(legalMoves, game.GetBoard());
 
 		// After filtering symmetric movements on an empty board, we expect to only have 2 options for each piece
 		EXPECT_EQ(legalMoves.size(), Game::c_PieceTypes * 2);
@@ -93,7 +93,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
-		FilterSymmetricMovements(legalMoves, game);
+		FilterSymmetricMovements(legalMoves, game.GetBoard());
 
 		/*
 		 * On a board with either x-axis or y-axis symmetry (but not both), the amount of available
@@ -115,12 +115,40 @@ namespace Alphalcazar::Strategy::MinMax {
 
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE);
 		auto legalMovesSize = legalMoves.size();
-		FilterSymmetricMovements(legalMoves, game);
+		FilterSymmetricMovements(legalMoves, game.GetBoard());
 
 		// On this board, that has no symmetry, we expect all legal moves to be available after filtering
 		EXPECT_EQ(legalMoves.size(), legalMovesSize);
 		// The legal moves size should be equal to all perimeter tiles (they are all empty) times
 		// al pieces minus 2, as player 1 has already placed 2 pieces on the board
 		EXPECT_EQ(legalMoves.size(), (Game::c_PieceTypes - 2) * game.GetBoard().GetPerimeterTiles().size());
+	}
+
+	TEST(LegalMovements, SortLegalMovements) {
+		std::vector<PieceSetup> pieceSetups{
+			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::SOUTH, { 1, 1 } }
+		};
+		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
+
+		std::vector<Game::PlacementMove> legalMoves {
+			// This movement will result in the piece not entering the board
+			{ { 1, 0 }, 3 },
+			// This movement will enter in the center lane
+			{ { 2, 0 }, 3 },
+			// This movement will enter in a lateral lane
+			{ { 3, 0 }, 3 }
+		};
+		std::size_t sizeBeforeSorting = legalMoves.size();
+		SortLegalMovements(legalMoves, game.GetBoard());
+		std::size_t sizeAfterSorting = legalMoves.size();
+
+		EXPECT_EQ(sizeBeforeSorting, sizeAfterSorting);
+
+		// We expect the movement that causes the piece to enter in the center lane
+		// to be first, followed by the movement that causes the piece to enter the lateral lane,
+		// and the movement that causes the piece not to enter at all last
+		EXPECT_EQ(legalMoves[0].Coordinates.x, 2);
+		EXPECT_EQ(legalMoves[1].Coordinates.x, 3);
+		EXPECT_EQ(legalMoves[2].Coordinates.x, 1);
 	}
 }

--- a/cpp/src/strategies/minmax/tests/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/tests/MinMaxStrategy.cpp
@@ -37,8 +37,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		Game::Coordinates winningCoordinates { 4, 2 };
 		for (Depth depth = 1; depth <= 2; depth++) {
 			MinMaxStrategy strategy { depth };
-			auto moveIndex = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
-			auto move = legalMoves[moveIndex];
+			auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
 
 			EXPECT_EQ(move.Coordinates, winningCoordinates);
 			EXPECT_EQ(move.PieceType, 2);
@@ -73,8 +72,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		// Player 2 should decide to play a piece on the (2,4) square regardless of the search depth
 		for (Depth depth = 1; depth <= 2; depth++) {
 			MinMaxStrategy strategy { depth };
-			auto moveIndex = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
-			auto move = legalMoves[moveIndex];
+			auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
 
 			EXPECT_EQ(move.Coordinates.x, 2);
 			EXPECT_EQ(move.Coordinates.y, 4);
@@ -108,8 +106,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE);
 
 		MinMaxStrategy strategy { 1 };
-		auto moveIndex = strategy.Execute(Game::PlayerId::PLAYER_ONE, legalMoves, game);
-		auto move = legalMoves[moveIndex];
+		auto move = strategy.Execute(Game::PlayerId::PLAYER_ONE, legalMoves, game);
 
 		// Positions at which the pushing piece can be played to avoid an immediate loss
 		std::vector<Game::Coordinates> expectedCoordinates {
@@ -141,8 +138,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
 
 		MinMaxStrategy strategy { 2 };
-		auto moveIndex = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
-		auto move = legalMoves[moveIndex];
+		auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
 
 		// Player 2 should postpone defeat this turn by playing the pusher piece at (2,0)
 		EXPECT_EQ(move.PieceType, Game::c_PusherPieceType);
@@ -174,8 +170,7 @@ namespace Alphalcazar::Strategy::MinMax {
 
 		MinMaxStrategy strategy { 2 };
 		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
-		auto moveIndex = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
-		auto move = legalMoves[moveIndex];
+		auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
 
 		// These are the perimeter tiles at which placing the 5 piece would cause it to enter the board
 		// Player 2 must place the piece on any tile except these ones to be able to win next round.

--- a/cpp/src/strategies/random/include/random/RandomStrategy.hpp
+++ b/cpp/src/strategies/random/include/random/RandomStrategy.hpp
@@ -19,7 +19,7 @@ namespace Alphalcazar::Strategy::Random {
 	class RandomStrategy final : public Game::Strategy {
 	public:
 		RandomStrategy();
-		virtual Game::PlacementMoveIndex Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) override;
+		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) override;
 	private:
 		std::random_device mRandomDevice;
 		std::mt19937 mRandomEngine;

--- a/cpp/src/strategies/random/src/random/RandomStrategy.cpp
+++ b/cpp/src/strategies/random/src/random/RandomStrategy.cpp
@@ -9,8 +9,8 @@ namespace Alphalcazar::Strategy::Random {
 		, mRandomEngine { mRandomDevice() }
 	{}
 
-	Game::PlacementMoveIndex RandomStrategy::Execute(Game::PlayerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game&) {
-		std::uniform_int_distribution<std::mt19937::result_type> distribution { 0, static_cast<Game::PlacementMoveIndex>(legalMoves.size() - 1) };
-		return static_cast<Game::PlacementMoveIndex>(distribution(mRandomEngine));
+	Game::PlacementMove RandomStrategy::Execute(Game::PlayerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game&) {
+		std::uniform_int_distribution<std::mt19937::result_type> distribution { 0, static_cast<std::mt19937::result_type>(legalMoves.size() - 1) };
+		return legalMoves[distribution(mRandomEngine)];
 	}
 }


### PR DESCRIPTION
Heuristic sorting of legal moves to try to get the most out of alpha-beta-pruning (it saves the most time if the options happen to be sorted from best to worst).

Did not affect performance very significantly (actually decreased it for depth 2), but it's a small win nonetheless, and it provides the base for exploring better sorting heuristics.

Before:
```
[2022-07-08 23:31:50.608] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-07-08 23:31:50.733] [info] First move at depth 2 took 124ms and calculated a score of -34
[2022-07-08 23:32:12.703] [info] First move at depth 3 took 21968ms and calculated a score of 0
```

After:
```
[2022-07-08 23:29:58.856] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-07-08 23:29:59.278] [info] First move at depth 2 took 421ms and calculated a score of -34
[2022-07-08 23:30:14.575] [info] First move at depth 3 took 15296ms and calculated a score of 0
```