### PR TITLE
Fix missing top-level alpha pruning

### DIFF
--- a/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
@@ -31,6 +31,7 @@ namespace Alphalcazar::Strategy::MinMax {
 			auto moveScore = GetNextBestScore(playerId, move, mDepth, game, alpha, c_BetaStartingValue);
 			if (moveScore > bestScore) {
 				bestScore = moveScore;
+				alpha = moveScore;
 				bestMove = move;
 			}
 		}


### PR DESCRIPTION
A blunder in the minmax implementation that was not making use of alpha-pruning on the top level of the tree (where it is most effective).

Before:
```
[2022-07-08 23:29:58.856] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-07-08 23:29:59.278] [info] First move at depth 2 took 421ms and calculated a score of -34
[2022-07-08 23:30:14.575] [info] First move at depth 3 took 15296ms and calculated a score of 0
```

After:
```
[2022-07-09 18:22:25.167] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-07-09 18:22:25.213] [info] First move at depth 2 took 44ms and calculated a score of -34
[2022-07-09 18:22:29.744] [info] First move at depth 3 took 4530ms and calculated a score of 0
```