### PR TITLE
Fix build for MSVS 16.x

### DIFF
--- a/cpp/src/game/include/game/PlacementMove.hpp
+++ b/cpp/src/game/include/game/PlacementMove.hpp
@@ -8,23 +8,22 @@
 namespace Alphalcazar::Game {
 	/*!
   	 * \brief Data structure with the minimnal information needed to uniquely represent a placement move.
-	 * 
+	 *
 	 * A placement move is defined as the action a player takes at the start of each turn,
 	 * where they take a piece they have in hand and place it on the perimeter of the board, facing
 	 * inwards.
 	 */
 	struct PlacementMove {
-		PlacementMove(const Coordinates& coordinates, PieceType pieceType)
-			: Coordinates{ coordinates }
-			, PieceType{ pieceType }
-		{}
+		PlacementMove();
+		PlacementMove(const Coordinates& coordinates, PieceType pieceType);
+		~PlacementMove();
 
 		Coordinates Coordinates;
 		PieceType PieceType;
 
-		bool operator==(const PlacementMove& other) const {
-			return PieceType == other.PieceType && Coordinates == other.Coordinates;
-		}
+		/// Returns whether the placement move isvalid
+		bool Valid() const;
+		bool operator==(const PlacementMove& other) const;
 	};
 
 }

--- a/cpp/src/game/src/game/PlacementMove.cpp
+++ b/cpp/src/game/src/game/PlacementMove.cpp
@@ -1,0 +1,23 @@
+#include "game/PlacementMove.hpp"
+
+namespace Alphalcazar::Game {
+	PlacementMove::PlacementMove()
+		: Coordinates{ Coordinates::Invalid() }
+		, PieceType{ 0 }
+	{}
+
+	PlacementMove::PlacementMove(const Game::Coordinates& coordinates, Game::PieceType pieceType)
+		: Coordinates{ coordinates }
+		, PieceType{ pieceType }
+	{}
+
+	PlacementMove::~PlacementMove() {}
+
+	bool PlacementMove::Valid() const {
+		return Coordinates.Valid() && PieceType != 0;
+	}
+
+	bool PlacementMove::operator==(const PlacementMove& other) const {
+		return PieceType == other.PieceType && Coordinates == other.Coordinates;
+	}
+}

--- a/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
@@ -25,7 +25,7 @@ namespace Alphalcazar::Strategy::MinMax {
 			 * we want to make use of all cores of the machine we are running on. To maximise alpha-beta-cutoffs while
 			 * making sure we make the most use of the cores of our current hardware, we create a thread pool with as
 			 * many threads as the maximum supported hardware concurrency (minus 1, for the main thread).
-			 * 
+			 *
 			 * We always want to have at least 1 worker thread to ensure that single-core machines still execute this strategy.
 			 */
 			std::size_t threadCount = std::max(std::thread::hardware_concurrency() - 1, 1U);
@@ -102,9 +102,9 @@ namespace Alphalcazar::Strategy::MinMax {
 			bestScore = std::max(nextBestScore, bestScore);
 			alpha = std::max(bestScore, alpha);
 			if (mMultithreaded) {
-				alpha = std::max(alpha, mFirstLevelAlpha.load());				
+				alpha = std::max(alpha, mFirstLevelAlpha.load());
 			}
-			
+
 			if (alpha > beta) {
 				break;
 			}


### PR DESCRIPTION
Microsoft Visual Studio 2019 doesn't implicitly generate default constructors (even when they are trivial to generate), so the creation of a `std::pair<Score, PlacementMove>` in a promise was failing due to the missing default `PlacementMove` constructor.

Also used the opportunity to reduce compile times a bit for files that include the PlacementMove.hpp file.