### PR TITLE
Improve pushing piece placement move heuristic

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -24,7 +24,7 @@ namespace Alphalcazar::Game {
 
 		/*!
 		 * \brief Places a given piece at the tile at the specified coordinates.
-		 * 
+		 *
 		 * May only be used to place pieces on the perimeter of the board, and automatically sets
 		 * the direction of the piece according to the placement direction of the perimeter tile.
 		 */
@@ -67,8 +67,9 @@ namespace Alphalcazar::Game {
 		 * \brief Returns a list of all pieces in play on the board (including perimeter)
 		 *
 		 * \param player If a valid player ID is specified, the function will only return pieces of this player
+		 * \param excludePerimeter If true, pieces on the perimeter of the board will not be included on the list
 		 */
-		std::vector<std::pair<Coordinates, Piece>> GetPieces(PlayerId player = PlayerId::NONE) const;
+		std::vector<std::pair<Coordinates, Piece>> GetPieces(PlayerId player = PlayerId::NONE, bool excludePerimeter = false) const;
 	private:
 		/*!
 		 * \brief Executes one piece movement, if the specified piece is on the board
@@ -83,9 +84,9 @@ namespace Alphalcazar::Game {
 		void RemovePiece(Tile& tile);
 		/*!
 		 * \brief Returns the ID of the player that has completed the specified row, or nullopt if no player has done so.
-		 * 
+		 *
 		 * \note A row is considered "complete" when all of the tiles along it are occupied by a piece of the same player.
-		 * 
+		 *
 		 * \param startCoordinate The coordinate where the row starts.
 		 * \param direction The direction we follow to check for row completness, until a perimeter tile is found.
 		 */
@@ -98,7 +99,7 @@ namespace Alphalcazar::Game {
 		 *
 		 * Each chained movement will be described as a pair of the source tile from which a piece needs to be moved from and
 		 * the target tile it needs to be moved to.
-		 * 
+		 *
 		 * \note The list will be returned in the order the movements are supposed to be executed (with the last piece of the chain
 		 * first and the movement of the pushing piece last)
 		 */
@@ -120,10 +121,10 @@ namespace Alphalcazar::Game {
 		std::array<std::array<Tile, c_PlayAreaSize>, c_PlayAreaSize> mTiles;
 		/*!
 		 * \brief An array containing the coordinates of each piece type, or invalid if the piece is not located on the board.
-		 * 
+		 *
 		 * The first \ref c_PieceTypes positions of the array are used by the pieces of player 1, and the next
 		 * \ref c_PieceTypes positions by the pieces of player 2.
-		 * 
+		 *
 		 * This information stored (even though it is also available on the tiles) to quickly find the coordinates/tile at which
 		 * a piece is located without having to loop over all the tiles.
 		 */

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -231,7 +231,7 @@ namespace Alphalcazar::Game {
 		return result;
 	}
 
-	std::vector<std::pair<Coordinates, Piece>> Board::GetPieces(PlayerId player) const {
+	std::vector<std::pair<Coordinates, Piece>> Board::GetPieces(PlayerId player, bool excludePerimeter) const {
 		std::vector<std::pair<Coordinates, Piece>> result;
 		// See the docstring of \ref mPlacedPieceCoordinates for more information.
 		// We iterate only over the positions that contain the coordinates of the pieces
@@ -253,6 +253,9 @@ namespace Alphalcazar::Game {
 		for (std::size_t i = min; i <= max; i++) {
 			auto coordinates = mPlacedPieceCoordinates[i];
 			if (coordinates.Valid()) {
+				if (excludePerimeter && coordinates.IsPerimeter()) {
+					continue;
+				}
 				if (auto* tile = GetTile(coordinates)) {
 					if (auto* piece = tile->GetPiece()) {
 						result.emplace_back(coordinates, *piece);

--- a/cpp/src/game/tests/Board.cpp
+++ b/cpp/src/game/tests/Board.cpp
@@ -10,7 +10,7 @@
 
 #include <array>
 
-namespace Alphalcazar::Game {	
+namespace Alphalcazar::Game {
 	TEST(Board, SetupTiles) {
 		Board board {};
 		EXPECT_EQ(board.IsFull(), false);
@@ -365,6 +365,9 @@ namespace Alphalcazar::Game {
 		Piece pieceFourPlayerOne{ PlayerId::PLAYER_ONE, 4 };
 		Piece pieceFourPlayerTwo{ PlayerId::PLAYER_TWO, 4 };
 
+		EXPECT_EQ(board.GetPieces().size(), 0);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE).size(), 0);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO).size(), 0);
 		board.PlacePiece({ 0, 1 }, pieceOnePlayerOne);
 		board.PlacePiece({ 1, 0 }, pieceOnePlayerTwo);
 		board.PlacePiece({ 2, 2 }, pieceFourPlayerOne, Direction::EAST);
@@ -397,5 +400,38 @@ namespace Alphalcazar::Game {
 			EXPECT_EQ(playerOnePieces.size(), 2);
 			EXPECT_EQ(playerTwoPieces.size(), 4);
 		}
+	}
+
+	TEST(Board, GetBoardPiecesWithoutPerimeter) {
+		Board board{};
+		Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
+		Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
+		Piece pieceTwoPlayerOne{ PlayerId::PLAYER_ONE, 2 };
+		Piece pieceTwoPlayerTwo{ PlayerId::PLAYER_TWO, 2 };
+
+		// Place a player 1 piece on the perimeter
+		board.PlacePiece({ 0, 1 }, pieceOnePlayerOne);
+		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 0);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, false).size(), 1);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, true).size(), 0);
+
+		// Place a player 2 piece on the perimeter
+		board.PlacePiece({ 2, 0 }, pieceOnePlayerTwo);
+		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 0);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, false).size(), 1);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, true).size(), 0);
+
+		// Place a player 1 piece on the center
+		board.PlacePiece({ 2, 2 }, pieceTwoPlayerOne, Direction::NORTH);
+		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 1);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, false).size(), 2);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, true).size(), 1);
+
+		// Place a player 2 piece on a corner
+		board.PlacePiece({ 3, 3 }, pieceTwoPlayerTwo, Direction::NORTH);
+		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 2);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, false).size(), 2);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, true).size(), 1);
+		EXPECT_EQ(board.GetPieces(PlayerId::NONE, false).size(), 4);
 	}
 }

--- a/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
@@ -25,10 +25,10 @@ namespace Alphalcazar::Strategy::MinMax {
 	/*!
 	 * \brief Filters a list of legal movements, erasing those that are duplicated once board
 	 *        symmetries are taken into account.
-	 * 
+	 *
 	 * This means that if several moves would cause the resulting board states to be identical with some symmetry
 	 * (ex. x-axis symmetry), only one of those moves (the first one) is kept in the list.
-	 * 
+	 *
 	 * \param legalMoves The list of legal moves to filter. Will potentially be modified.
 	 * \param board The board of the game for which the legal movements are valid.
 	 */
@@ -37,12 +37,13 @@ namespace Alphalcazar::Strategy::MinMax {
 	/*!
 	 * \brief Sorts a list of legal movements by the heuristic score we expect to obtain from playing
 	 *        each of those movements.
-	 * 
+	 *
 	 * Alpha-beta-pruning algorithms are most efficient when the best moves are explored first. Since this is
 	 * not possible until the branch is actually explore, we use this heuristic to try to approximate it.
-	 * 
+	 *
+	 * \param playerId The ID of the player who's turn it is to play.
 	 * \param legalMoves The list of legal moves to sort. Will potentially be modified.
 	 * \param board The board of the game for which the legal movements are valid.
 	 */
-	void SortLegalMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board);
+	void SortLegalMovements(Game::PlayerId playerId, std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board);
 }

--- a/cpp/src/strategies/minmax/include/minmax/config.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/config.hpp
@@ -13,7 +13,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	 *
 	 * \note A loss will be represented with the negated win condition score.
 	 */
-	constexpr Score c_WinConditionScore = 1000;
+	constexpr Score c_WinConditionScore = 10000;
 	/*!
 	 * \brief A penalty that will be subtracted from a movement's score each movement for each level of depth.
 	 *
@@ -30,7 +30,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		80, // Piece 1
 		120, // Piece 2
 		140, // Piece 3
-		-80, // Piece 4
+		-40, // Piece 4
 		100 // Piece 5
 	}};
 
@@ -40,6 +40,20 @@ namespace Alphalcazar::Strategy::MinMax {
 	constexpr float c_PieceAboutToExitMultiplier = 0.7f;
 	constexpr float c_LateralCenterLanePieceMultiplier = 1.f;
 
-	constexpr Score c_CenterLanePieceMultiplier = 2;
-	constexpr Score c_LateralLanePieceMultiplier = 1;
+	// Heuristic values that only apply to placement moves (for sorting purposes)
+
+	/*!
+	 * \brief A bonus score added to the pusher (4) piece per piece that the opponent has on the board (excluding perimeter).
+	 *
+	 * \note Will only be applied if the opponent has at least 2 pieces on the board (could be threatening a potential mate in 1).
+	 *
+	 * The reason for this is that the pusher piece usually has a higher values on the player's hand than on the board, as it can be used
+	 * to avoid otherwise forced wins by the opponent. Therefore playing it when there is no immediate loss threat makes no sense, but as
+	 * the opponent gets more pieces on the board, the chance increases that playing it is the best move.
+	 *
+	 * Its value is set to 30 because at the current heuristic score of the pusher piece (-40), when the opponent has 2 pieces on the board
+	 * it will result in a score of 130, making it the second piece to be evaluated (after piece 3), and the highest score if the opponent has
+	 * 3 or more pieces on the board. It also makes sure the score of a pusher can't exceed the win score (-40 + 85 * 5 * 1.7 = 655).
+	 */
+	constexpr Score c_PusherBonusPerOpponentPiece = 85;
 }

--- a/cpp/src/strategies/minmax/include/minmax/minmax_aliases.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/minmax_aliases.hpp
@@ -4,5 +4,5 @@
 
 namespace Alphalcazar::Strategy::MinMax {
 	using Depth = std::uint8_t;
-	using Score = std::int16_t;
+	using Score = std::int32_t;
 }

--- a/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
@@ -38,7 +38,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	Game::PlacementMove MinMaxStrategy::Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) {
 		auto filteredMoves = legalMoves;
 		FilterSymmetricMovements(filteredMoves, game.GetBoard());
-		SortLegalMovements(filteredMoves, game.GetBoard());
+		SortLegalMovements(playerId, filteredMoves, game.GetBoard());
 
 		assert(!filteredMoves.empty());
 		Score bestScore = c_AlphaStartingValue;
@@ -96,7 +96,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		// We are in "Max" so we are evaluating the player who is executing the strategy
 		auto legalMoves = game.GetLegalMoves(playerId);
 		FilterSymmetricMovements(legalMoves, game.GetBoard());
-		SortLegalMovements(legalMoves, game.GetBoard());
+		SortLegalMovements(playerId, legalMoves, game.GetBoard());
 		for (const auto& move : legalMoves) {
 			auto nextBestScore = GetNextBestScore(playerId, move, depth, game, alpha, beta);
 
@@ -122,7 +122,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		auto opponentId = playerId == Game::PlayerId::PLAYER_ONE ? Game::PlayerId::PLAYER_TWO : Game::PlayerId::PLAYER_ONE;
 		auto legalMoves = game.GetLegalMoves(opponentId);
 		FilterSymmetricMovements(legalMoves, game.GetBoard());
-		SortLegalMovements(legalMoves, game.GetBoard());
+		SortLegalMovements(playerId, legalMoves, game.GetBoard());
 		for (const auto& move : legalMoves) {
 			auto nextBestScore = GetNextBestScore(playerId, move, depth, game, alpha, beta);
 			bestScore = std::min(nextBestScore, bestScore);

--- a/cpp/src/strategies/minmax/tests/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/tests/LegalMovements.cpp
@@ -98,7 +98,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		/*
 		 * On a board with either x-axis or y-axis symmetry (but not both), the amount of available
 		 * perimeter tiles we expect to be available for each piece goes as follows:
-		 * 
+		 *
 		 * 1) One full side (of size BoardSize)
 		 * 2) Two sides cut in half (rounding up to include the center row in boards with odd sizes)
 		 */
@@ -139,7 +139,7 @@ namespace Alphalcazar::Strategy::MinMax {
 			{ { 3, 0 }, 3 }
 		};
 		std::size_t sizeBeforeSorting = legalMoves.size();
-		SortLegalMovements(legalMoves, game.GetBoard());
+		SortLegalMovements(Game::PlayerId::PLAYER_ONE, legalMoves, game.GetBoard());
 		std::size_t sizeAfterSorting = legalMoves.size();
 
 		EXPECT_EQ(sizeBeforeSorting, sizeAfterSorting);


### PR DESCRIPTION
Take into account the amount of pieces on the board for the placement move heuristic of pushing pieces.

Before:
```
[2022-07-16 09:21:31.927] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-16 09:21:32.001] [info] First move at depth 2 took 67ms and calculated a score of -34
[2022-07-16 09:21:33.698] [info] First move at depth 3 took 1689ms and calculated a score of 35
[2022-07-16 09:26:58.508] [info] First move at depth 4 took 324800ms and calculated a score of -83

[2022-07-16 09:13:15.593] [info] Game at depth 1 took 8ms
[2022-07-16 09:13:15.850] [info] Game at depth 2 took 250ms
[2022-07-16 09:13:37.439] [info] Game at depth 3 took 21582ms
```

After:
```
[2022-07-16 09:16:39.939] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-16 09:16:40.024] [info] First move at depth 2 took 78ms and calculated a score of -34
[2022-07-16 09:16:41.487] [info] First move at depth 3 took 1455ms and calculated a score of 35
[2022-07-16 09:21:02.035] [info] First move at depth 4 took 260542ms and calculated a score of -64

[2022-07-16 09:15:55.631] [info] Game at depth 1 took 6ms
[2022-07-16 09:15:55.846] [info] Game at depth 2 took 208ms
[2022-07-16 09:16:17.667] [info] Game at depth 3 took 21814ms
```
