### PR TITLE
Remove coordinates member from Tile

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -58,8 +58,8 @@ namespace Alphalcazar::Game {
 		std::vector<const Tile*> GetTiles() const;
 		/// Returns all perimeter tiles of the board
 		std::vector<const Tile*> GetPerimeterTiles() const;
-		/// Returns a list of all tiles where a player may legally place a piece on their turn
-		std::vector<const Tile*> GetLegalPlacementTiles() const;
+		/// Returns a list of all coordinates where a player may legally place a piece on their turn
+		std::vector<Coordinates> GetLegalPlacementCoordinates() const;
 
 		/// Returns the tile a given piece is placed on, or nullptr if the specified piece is not on the board
 		Tile* GetPieceTile(const Piece& piece);
@@ -79,7 +79,7 @@ namespace Alphalcazar::Game {
 		 */
 		BoardMovesCount ExecutePieceMove(const Piece& piece);
 		/// Moves the piece from the source tile to the target tile
-		void MovePiece(Tile& source, Tile& target);
+		void MovePiece(Tile& source, Tile& target, const Coordinates& targetCoordinates);
 		/// Removes the piece (if any) on the specified tile
 		void RemovePiece(Tile& tile);
 		/*!
@@ -92,7 +92,7 @@ namespace Alphalcazar::Game {
 		 */
 		std::optional<PlayerId> CheckRowCompleteness(const Coordinates& startCoordinate, Direction direction, Coordinate length) const;
 
-		using MovementDescription = std::pair<Tile*, Tile*>;
+		using MovementDescription = std::tuple<Tile*, Tile*, Coordinates>;
 		/*!
 		 * \brief Returns a list of chained push movements that occur when a piece wants to move from the specified
 		 *        source coordinates in the specified direction.

--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -1,22 +1,23 @@
 #pragma once
 
 #include "aliases.hpp"
-
+#include "game/parameters.hpp"
 #include <fmt/format.h>
+#include <array>
 
 namespace Alphalcazar::Game {
+	constexpr Coordinate c_InvalidCoordinate = std::numeric_limits<Coordinate>::max();
+
 	/*!
 	 * \brief Helper class to work with the 2D coordinate system of the tiles of the board.
-	 * 
+	 *
 	 * Represents the coordinates of a (potential) tile position on the board. The coordinate system of the board
 	 * has its origin (0, 0) at the south-west (bottom-left) most corner of the board. X coordinates increase to the east
 	 * and Y coordinates increase to the north.
 	 */
 	struct Coordinates {
-		Coordinate x, y;
-		Coordinates();
-		Coordinates(Coordinate x, Coordinate y);
-		~Coordinates();
+		Coordinate x = c_InvalidCoordinate;
+		Coordinate y = c_InvalidCoordinate;
 
 		bool operator==(const Coordinates& coord) const;
 		bool operator!=(const Coordinates& coord) const;
@@ -53,6 +54,29 @@ namespace Alphalcazar::Game {
 
 		/// Builds and returns an instance of invalid coordinates
 		static Coordinates Invalid();
+
+		/// Returns a list of all coordinates that correspond to valid perimeter tiles
+		static constexpr std::array<Coordinates, c_PerimeterTileCount> GetPerimeterCoordinates() {
+			std::array<Coordinates, c_PerimeterTileCount> result{};
+			std::size_t i = 0;
+			for (Coordinate x = 1; x <= c_BoardSize; x++) {
+				result[i] = { x, 0 };
+				i++;
+			}
+			for (Coordinate x = 1; x <= c_BoardSize; x++) {
+				result[i] = { x, c_PlayAreaSize - 1 };
+				i++;
+			}
+			for (Coordinate y = 1; y <= c_BoardSize; y++) {
+				result[i] = { 0, y };
+				i++;
+			}
+			for (Coordinate y = 1; y <= c_BoardSize; y++) {
+				result[i] = { c_PlayAreaSize - 1, y };
+				i++;
+			}
+			return result;
+		}
 	};
 }
 
@@ -61,7 +85,7 @@ namespace std {
 	* The \ref Coordinates class implements a hashing function to be able to be used as a key
 	* for unordered maps.
 	*/
-	template <> 
+	template <>
 	struct hash<Alphalcazar::Game::Coordinates> {
 		std::size_t operator()(const Alphalcazar::Game::Coordinates& coordinates) const noexcept {
 			auto xHash = hash<Alphalcazar::Game::Coordinate>()(coordinates.x);

--- a/cpp/src/game/include/game/Tile.hpp
+++ b/cpp/src/game/include/game/Tile.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "aliases.hpp"
-#include "Coordinates.hpp"
 #include "Piece.hpp"
 #include <memory>
 #include <optional>
@@ -9,13 +8,12 @@
 namespace Alphalcazar::Game {
 	/*!
 	 * \brief Represents a single tile of the board.
-	 * 
+	 *
 	 * It holds information about which piece (if any) is placed on it.
 	 */
 	class Tile {
 	public:
 		Tile();
-		Tile(const Coordinates& coordinates);
 		Tile(const Tile& other);
 		~Tile();
 
@@ -23,21 +21,12 @@ namespace Alphalcazar::Game {
 		void PlacePiece(const Piece& piece);
 		/// Removes the piece that was placed on this tile, if any
 		void RemovePiece();
-		/// Returns the coordinates at which this tile is located on its parent board
-		const Coordinates& GetCoordinates() const;
-		/*!
-		 * \brief Returns the direction in which pieces may be legally placed on this tile.
-		 * 
-		 * Returns an invalid direction if the tile is not a perimeter tile.
-		 */
-		Direction GetLegalPlacementDirection() const;
 		/// Returns the piece that is currently placed on this tile, or std::nullopt if no piece is on this tile
 		const Piece* GetPiece() const;
 		Piece* GetPiece();
 
 		bool HasPiece() const;
 	private:
-		Coordinates mCoordinates;
 		Piece mPiece;
 	};
 }

--- a/cpp/src/game/include/game/aliases.hpp
+++ b/cpp/src/game/include/game/aliases.hpp
@@ -8,7 +8,7 @@ namespace Alphalcazar::Game {
 	constexpr PieceType c_InvalidPieceType = 0;
 	using Coordinate = std::int8_t; // (+-128 should be more than enough for a 3x3 board)
 
-	enum class GameResult {
+	enum class GameResult : std::uint8_t {
 		NONE = 0,
 		DRAW,
 		PLAYER_ONE_WINS,

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -1,11 +1,8 @@
 #include "game/Coordinates.hpp"
-#include "game/parameters.hpp"
 
 #include <util/Log.hpp>
-#include <array>
 
 namespace Alphalcazar::Game {
-	constexpr Coordinate c_InvalidCoordinate = std::numeric_limits<Coordinate>::max();
 
 	// Small macro to define the offsets of \ref c_DirectionOffsets. The reason for this is that in order for the
 	// array to be a valid constexpr, we must cast the int literals to Coordinate (std::int8_t), as implicit type
@@ -29,18 +26,6 @@ namespace Alphalcazar::Game {
 		DIR_OFFSETS(1, 1), // NORTH_EAST
 		DIR_OFFSETS(-1, 1), // NORTH_WEST
 	}};
-
-	Coordinates::Coordinates()
-		: x { c_InvalidCoordinate }
-		, y { c_InvalidCoordinate }
-	{}
-
-	Coordinates::Coordinates(Coordinate x, Coordinate y)
-		: x{ x }
-		, y{ y }
-	{}
-
-	Coordinates::~Coordinates() {}
 
 	bool Coordinates::operator==(const Coordinates& coord) const {
 		return x == coord.x && y == coord.y;
@@ -101,7 +86,7 @@ namespace Alphalcazar::Game {
 		}
 
 		auto& offset = c_DirectionOffsets[static_cast<std::size_t>(direction)];
-		return Coordinates(x + offset.first * distance, y + offset.second * distance);
+		return Coordinates{ static_cast<Coordinate>(x + offset.first * distance), static_cast<Coordinate>(y + offset.second * distance) };
 	}
 
 	bool Coordinates::Valid() const {

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -103,12 +103,12 @@ namespace Alphalcazar::Game {
 
 	std::vector<PlacementMove> Game::GetLegalMoves(PlayerId player) const {
 		std::vector<PlacementMove> result;
-		auto legalTiles = mBoard.GetLegalPlacementTiles();
+		auto legalCoordinates = mBoard.GetLegalPlacementCoordinates();
 		std::vector<Piece> pieces = GetPiecesInHand(player);
-		result.reserve(pieces.size() * legalTiles.size());
-		for (auto* tile : legalTiles) {
+		result.reserve(pieces.size() * legalCoordinates.size());
+		for (auto& coordinates : legalCoordinates) {
 			for (auto& piece : pieces) {
-				result.emplace_back(tile->GetCoordinates(), piece.GetType());
+				result.emplace_back(coordinates, piece.GetType());
 			}
 		}
 		return result;

--- a/cpp/src/game/src/game/Tile.cpp
+++ b/cpp/src/game/src/game/Tile.cpp
@@ -5,13 +5,8 @@
 namespace Alphalcazar::Game {
 	Tile::Tile() {}
 
-	Tile::Tile(const Coordinates& coordinates)
-		: mCoordinates{ coordinates }
-	{}
-
 	Tile::Tile(const Tile& other)
-		: mCoordinates { other.mCoordinates }
-		, mPiece { other.mPiece }
+		: mPiece { other.mPiece }
 	{}
 
 	Tile::~Tile() {}
@@ -26,14 +21,6 @@ namespace Alphalcazar::Game {
 	void Tile::RemovePiece() {
 		// Replace the existing piece with an invalid piece
 		mPiece = {};
-	}
-
-	const Coordinates& Tile::GetCoordinates() const {
-		return mCoordinates;
-	}
-
-	Direction Tile::GetLegalPlacementDirection() const {
-		return mCoordinates.GetLegalPlacementDirection();
 	}
 
 	bool Tile::HasPiece() const {

--- a/cpp/src/game/tests/Board.cpp
+++ b/cpp/src/game/tests/Board.cpp
@@ -23,10 +23,8 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, PlacePiece) {
 		Board board {};
-
 		std::size_t pieceIndex = 0;
-		for (auto* tile : board.GetPerimeterTiles()) {
-			auto& coordinates = tile->GetCoordinates();
+		for (auto& coordinates : Coordinates::GetPerimeterCoordinates()) {
 			Piece piece = c_AllPieces[pieceIndex];
 			pieceIndex++;
 			if (pieceIndex >= (c_PieceTypes * 2) - 1) {
@@ -43,12 +41,11 @@ namespace Alphalcazar::Game {
 		Board board {};
 
 		std::size_t pieceIndex = 0;
-		for (auto* tile : board.GetTiles()) {
-			auto& coordinates = tile->GetCoordinates();
-			if (!coordinates.IsPerimeter()) {
+		for (Coordinate x = 1; x <= c_BoardSize; x++) {
+			for (Coordinate y = 1; y <= c_BoardSize; y++) {
 				Piece piece = c_AllPieces[pieceIndex];
 				pieceIndex++;
-				board.GetTile(coordinates)->PlacePiece(piece);
+				board.GetTile(x, y)->PlacePiece(piece);
 			}
 		}
 		EXPECT_EQ(board.IsFull(), true);
@@ -321,16 +318,16 @@ namespace Alphalcazar::Game {
 		Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
 		Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
 
-		auto legalPlacementTiles = board.GetLegalPlacementTiles();
+		auto legalPlacementTiles = board.GetLegalPlacementCoordinates();
 		// On an empty board we should have as many options as the size of the perimeter
 		// which is the play area size square minus the board size square minus the 4 corners
 		constexpr Coordinate perimeterSize = c_PlayAreaSize * c_PlayAreaSize - c_BoardSize * c_BoardSize - 4;
 		EXPECT_EQ(legalPlacementTiles.size(), perimeterSize);
 
-		board.PlacePiece(legalPlacementTiles[0]->GetCoordinates(), pieceOne);
-		board.PlacePiece(legalPlacementTiles[1]->GetCoordinates(), pieceTwo);
+		board.PlacePiece(legalPlacementTiles[0], pieceOne);
+		board.PlacePiece(legalPlacementTiles[1], pieceTwo);
 
-		auto legalTilesAfterPlacement = board.GetLegalPlacementTiles();
+		auto legalTilesAfterPlacement = board.GetLegalPlacementCoordinates();
 		EXPECT_EQ(legalTilesAfterPlacement.size(), perimeterSize - 2);
 	}
 

--- a/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
@@ -76,24 +76,20 @@ namespace Alphalcazar::Strategy::MinMax {
 		// piece not even entering the board. While this can be beneficial in some very specific situations,
 		// most times it would just be a blunder, so it makes sense to assign these movements the lowest score
 		if (move.PieceType != Game::c_PusherPieceType) {
-			if (auto* moveTile = board.GetTile(move.Coordinates)) {
-				auto placementDirection = moveTile->GetLegalPlacementDirection();
-				auto pieceTargetCoordinate = move.Coordinates.GetCoordinateInDirection(placementDirection, 1);
-				if (auto* pieceTargetTilePiece = board.GetTile(pieceTargetCoordinate)->GetPiece()) {
-					// There's a piece on the tile that our piece is looking at
-					// We check if we can expect the piece to be gone before our piece moves
-					// or if the piece can be pushed by us
-					if (!pieceTargetTilePiece->IsPushable()) {
-						auto blockingPieceTargetCoordinate = pieceTargetCoordinate.GetCoordinateInDirection(pieceTargetTilePiece->GetMovementDirection(), 1);
-						// We check if the target piece moves after us, or if it will attempt to move to the position where we have placed
-						// the piece, causing its movement to be blocked
-						if (pieceTargetTilePiece->GetType() > move.PieceType || blockingPieceTargetCoordinate == move.Coordinates) {
-							return 0;
-						}
+			auto placementDirection = move.Coordinates.GetLegalPlacementDirection();
+			auto pieceTargetCoordinate = move.Coordinates.GetCoordinateInDirection(placementDirection, 1);
+			if (auto* pieceTargetTilePiece = board.GetTile(pieceTargetCoordinate)->GetPiece()) {
+				// There's a piece on the tile that our piece is looking at
+				// We check if we can expect the piece to be gone before our piece moves
+				// or if the piece can be pushed by us
+				if (!pieceTargetTilePiece->IsPushable()) {
+					auto blockingPieceTargetCoordinate = pieceTargetCoordinate.GetCoordinateInDirection(pieceTargetTilePiece->GetMovementDirection(), 1);
+					// We check if the target piece moves after us, or if it will attempt to move to the position where we have placed
+					// the piece, causing its movement to be blocked
+					if (pieceTargetTilePiece->GetType() > move.PieceType || blockingPieceTargetCoordinate == move.Coordinates) {
+						return 0;
 					}
 				}
-			} else {
-				Utils::LogError("Legal move pointed at {}, but no board tile was found at those coordinates.", move.Coordinates);
 			}
 		}
 


### PR DESCRIPTION
Remove the `mCoordinates` member from the `Tile` class, which was essentially just holding duplicate information.
This effectively reduces the size of `Tile` from 5 to 3 bytes.

Before:
```
[2022-07-16 19:01:39.086] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-16 19:01:39.163] [info] First move at depth 2 took 70ms and calculated a score of -34
[2022-07-16 19:01:40.707] [info] First move at depth 3 took 1537ms and calculated a score of 35
[2022-07-16 19:06:27.324] [info] First move at depth 4 took 286609ms and calculated a score of -64
```

After:
```
[2022-07-16 18:57:43.924] [info] First move at depth 1 took 6ms and calculated a score of 0
[2022-07-16 18:57:43.993] [info] First move at depth 2 took 58ms and calculated a score of -34
[2022-07-16 18:57:45.769] [info] First move at depth 3 took 1768ms and calculated a score of 35
[2022-07-16 19:01:09.578] [info] First move at depth 4 took 203797ms and calculated a score of -64
```