### PR TITLE
Preallocate space for the GetPieces result vector

### DIFF
--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -224,6 +224,11 @@ namespace Alphalcazar::Game {
 
 	std::vector<std::pair<Coordinates, Piece>> Board::GetPieces(PlayerId player, bool excludePerimeter) const {
 		std::vector<std::pair<Coordinates, Piece>> result;
+		// We preallocate space in the vector according to the max amount of pieces that could
+		// fit in the vector if all relevant pieces were on the board. Will waste memory sometimes
+		// but memory usage is not as much of an issue as CPU usage here.
+		result.reserve(player == PlayerId::NONE ? c_PieceTypes * 2 : c_PieceTypes);
+
 		// See the docstring of \ref mPlacedPieceCoordinates for more information.
 		// We iterate only over the positions that contain the coordinates of the pieces
 		// of the specified player.


### PR DESCRIPTION
Profiling hinted towards constant reallocations of the result vector of the GetPieces result vector being a local performance bottleneck, so we preallocate the max possible size of the vector from the start.

Before:
```
[2022-07-16 18:57:43.924] [info] First move at depth 1 took 6ms and calculated a score of 0
[2022-07-16 18:57:43.993] [info] First move at depth 2 took 58ms and calculated a score of -34
[2022-07-16 18:57:45.769] [info] First move at depth 3 took 1768ms and calculated a score of 35
[2022-07-16 19:01:09.578] [info] First move at depth 4 took 203797ms and calculated a score of -64
```

After:
```
[2022-07-16 19:14:10.733] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-16 19:14:10.798] [info] First move at depth 2 took 58ms and calculated a score of -34
[2022-07-16 19:14:12.177] [info] First move at depth 3 took 1372ms and calculated a score of 35
[2022-07-16 19:17:13.325] [info] First move at depth 4 took 181140ms and calculated a score of -64
```