### PR TITLE
Reduce the size of Game & Piece data structures

### DIFF
--- a/cpp/src/game/include/game/Game.hpp
+++ b/cpp/src/game/include/game/Game.hpp
@@ -71,10 +71,6 @@ namespace Alphalcazar::Game {
 
 		/// Returns a list of all pieces that the specified player has in hand (are not placed on the board)
 		std::vector<Piece> GetPiecesInHand(PlayerId player) const;
-
-		using PlayerMovesExecutedCallback = void();
-		/// Callback executed after both players have placed their piece on the board, and before board movements are executed
-		Utils::CallbackHandler<PlayerMovesExecutedCallback>& OnPlayerMovesExecuted();
 	private:
 		/// Exchange the player with initiative
 		void SwapPlayerWithInitiative();
@@ -101,7 +97,5 @@ namespace Alphalcazar::Game {
 		Board mBoard;
 		/// The state of the game. See \ref GameState for more info
 		GameState mState;
-
-		Utils::CallbackHandler<PlayerMovesExecutedCallback> mPlayerMovesExecutedCallbacks;
 	};
 }

--- a/cpp/src/game/include/game/Piece.hpp
+++ b/cpp/src/game/include/game/Piece.hpp
@@ -6,7 +6,7 @@
 namespace Alphalcazar::Game {
 	/*!
 	 * \brief Represents a piece that belongs to a player.
-	 * 
+	 *
 	 * Can be either placed on the board or in its owner's hand.
 	 * While the piece is in play on the board, it will have a movement direction.
 	 */
@@ -31,9 +31,29 @@ namespace Alphalcazar::Game {
 
 		void SetMovementDirection(Direction direction);
 	private:
-		PieceType mType = c_InvalidPieceType;
-		/// The movement direction of the piece while it is in play on the board
-		Direction mDirection = Direction::NONE;
-		PlayerId mOwner = PlayerId::NONE;
+		/*!
+		 * \brief The type, or movement order, of the piece.
+		 *
+		 * The type of a piece indicates in which order (relative to other pieces) the piece will execute its movement
+		 * in the movement phase at the end of each turn.
+		 *
+		 * \note Since currently there are 6 possible values for this state (5 pieces and invalid), we assign 3 bits (8 possible states)
+		 *       to this member.
+		 */
+		PieceType mType : 3;
+		/*!
+		 * \brief The movement direction of the piece while it is in play on the board
+		 *
+		 * \note In theory there are 9 possible states for this field (4 cardinal directions, 4 intercardinal directions and the invalid state).
+		 *       However, the game rules currently only allow pieces to have one of the 4 cardinal directions. Therefore we can (until this changes) assign
+		 *       3 bits (8 possible states) to this field. This makes the whole \ref Piece struct as a whole take up 1 byte, which is very convenient.
+		 */
+		Direction mDirection : 3;
+		/*!
+		 * \brief The ID of the player that owns this piece.
+		 *
+		 * \note Since currently there are 3 possible values for this state (2 players and none), we assign 2 bits (4 possible states) to this member.
+		 */
+		PlayerId mOwner : 2;
 	};
 }

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -31,7 +31,6 @@ namespace Alphalcazar::Game {
 		auto result = GameResult::NONE;
 		ExecutePlacementMove(activePlayer, move);
 		if (mState.FirstMoveExecuted) {
-			mPlayerMovesExecutedCallbacks.Invoke();
 			result = EvaluateTurnEndPhase();
 		} else {
 			mState.FirstMoveExecuted = true;
@@ -63,8 +62,6 @@ namespace Alphalcazar::Game {
 		} else {
 			ExecutePlayerMove(PlayerId::PLAYER_ONE, secondPlayerStrategy);
 		}
-
-		mPlayerMovesExecutedCallbacks.Invoke();
 	}
 
 	void Game::ExecutePlayerMove(PlayerId playerId, Strategy& strategy) {
@@ -152,9 +149,5 @@ namespace Alphalcazar::Game {
 
 	const Board& Game::GetBoard() const {
 		return mBoard;
-	}
-
-	Utils::CallbackHandler<Game::PlayerMovesExecutedCallback>& Game::OnPlayerMovesExecuted() {
-		return mPlayerMovesExecutedCallbacks;
 	}
 }

--- a/cpp/src/game/src/game/Piece.cpp
+++ b/cpp/src/game/src/game/Piece.cpp
@@ -2,7 +2,11 @@
 #include "game/parameters.hpp"
 
 namespace Alphalcazar::Game {
-	Piece::Piece() noexcept {}
+	Piece::Piece() noexcept
+		: mType{ c_InvalidPieceType }
+		, mDirection{ Direction::NONE }
+		, mOwner{ PlayerId::NONE }
+	{}
 
 	Piece::Piece(PlayerId owner, PieceType type) noexcept
 		: mType{ type }
@@ -36,7 +40,7 @@ namespace Alphalcazar::Game {
 	bool Piece::IsPusher() const {
 		return mType == c_PusherPieceType;
 	}
-	
+
 	bool Piece::IsValid() const {
 		return mType != c_InvalidPieceType && mOwner != PlayerId::NONE;
 	}

--- a/cpp/src/game/tests/Game.cpp
+++ b/cpp/src/game/tests/Game.cpp
@@ -34,23 +34,6 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(game.GetPiecesInHand(PlayerId::PLAYER_TWO).size(), c_PieceTypes);
 	}
 
-	TEST(Game, TestMovesExecutedCallback) {
-		Game game{};
-		std::size_t counter = 0;
-		std::ignore = game.OnPlayerMovesExecuted().Register([&counter]() {
-			counter++;
-		});
-		game.PlayNextPlacementMove({ { 0, 2 }, 5 });
-		EXPECT_EQ(counter, 0);
-		game.PlayNextPlacementMove({ { 0, 3 }, 5 });
-		// After 2 moves have been played, we expect the counter to increase as a complete turn has been played
-		EXPECT_EQ(counter, 1);
-
-		MockStrategy strategy;
-		game.PlayTurn(strategy, strategy);
-		EXPECT_EQ(counter, 2);
-	}
-
 	/*!
 	 * \brief Checks if the amount of legal moves is consistent with the pieces in hand of a player
 	 *

--- a/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
@@ -22,8 +22,8 @@ namespace Alphalcazar::Strategy::MinMax {
 	/*!
 	 * \brief A strategy that determines the move to play by using a min-max algorithm
 	 *        on the available legal moves.
-	 * 
-	 * Like a min-max chess engine, it is limited to a certain depth (due to the computational complexity 
+	 *
+	 * Like a min-max chess engine, it is limited to a certain depth (due to the computational complexity
 	 * of running this algorithm on this kind of game) and uses heuristics to evaluate the board score
 	 * when the max depth is reached.
 	 */
@@ -51,15 +51,15 @@ namespace Alphalcazar::Strategy::MinMax {
 
 		Score GetNextBestScore(Game::PlayerId playerId, const Game::PlacementMove& move, Depth depth, const Game::Game& game, Score alpha, Score beta);
 
-		/// The max depth to explore on max-max searches
+		/// The thread pool that will run the min-max algorithm tasks if mMultithreaded is true
+		std::unique_ptr<Utils::ThreadPool> mThreadPool;
+		std::atomic<Score> mFirstLevelAlpha = 0;
+
+		/// The score calculated for the move returned by the last \ref Execute function call
+		Score mLastExecutedMoveScore = 0;
+		/// The max depth to explore on min-max searches
 		Depth mDepth;
 		/// Whether the min-max search will be run on multiple threads
 		bool mMultithreaded;
-		/// The score calculated for the move returned by the last \ref Execute function call
-		Score mLastExecutedMoveScore = 0;
-
-		std::atomic<Score> mFirstLevelAlpha = 0;
-		/// The thread pool that will run the min-max algorithm tasks if mMultithreaded is true
-		std::unique_ptr<Utils::ThreadPool> mThreadPool;
 	};
 }


### PR DESCRIPTION
Reduced the size of most data structures in the `Game` class, mainly through the use of bitfields in the Piece class and by removing the unused `OnPlayerMovesExecuted()` callback handler.

Also considerably reduced the size of the `CallbackHandler` class by using a vector instead of an unordered_map in case it is necessary to add to the `Game` class in the future (for example when a UI is implemented).

Before:
```
sizeof(Game): 224 bytes
sizeof(Board): 145 bytes
sizeof(Piece / Tile): 5 bytes

[2022-07-16 21:18:20.426] [info] First move at depth 1 took 4ms and calculated a score of 0
[2022-07-16 21:18:20.501] [info] First move at depth 2 took 69ms and calculated a score of -34
[2022-07-16 21:18:22.234] [info] First move at depth 3 took 1726ms and calculated a score of 35
[2022-07-16 21:21:43.995] [info] First move at depth 4 took 201754ms and calculated a score of -64
```

After:
```
sizeof(Game): 50 bytes
sizeof(Board): 45 bytes
sizeof(Piece / Tile): 1 byte

[2022-07-16 20:42:13.403] [info] First move at depth 1 took 4ms and calculated a score of 0
[2022-07-16 20:42:13.477] [info] First move at depth 2 took 66ms and calculated a score of -34
[2022-07-16 20:42:14.965] [info] First move at depth 3 took 1479ms and calculated a score of 35
[2022-07-16 20:45:24.492] [info] First move at depth 4 took 189519ms and calculated a score of -64
```