### PR TITLE
Replace Board::GetPieces uses with more specialized functions

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -66,10 +66,30 @@ namespace Alphalcazar::Game {
 		/*!
 		 * \brief Returns a list of all pieces in play on the board (including perimeter)
 		 *
-		 * \param player If a valid player ID is specified, the function will only return pieces of this player
-		 * \param excludePerimeter If true, pieces on the perimeter of the board will not be included on the list
+		 * \param player If a valid player ID is specified, the function will only return pieces of this player.
+		 * \param excludePerimeter If true, pieces on the perimeter of the board will not be included on the list.
 		 */
 		std::vector<std::pair<Coordinates, Piece>> GetPieces(PlayerId player = PlayerId::NONE, bool excludePerimeter = false) const;
+		/*!
+		 * \brief Returns the amount of pieces a player has on the board.
+		 *
+		 * Much faster than calling \ref GetPieces if you're only interested in the amount of pieces on the board.
+		 *
+		 * \param player The player for which to return the piece count.
+		 * \param excludePerimeter If true, pieces on the perimeter of the board will not be counted.
+		 */
+		std::size_t GetPieceCount(PlayerId player, bool excludePerimeter = false) const;
+		/*!
+		 * \brief Returns an array indicating if a player's piece of a certain type is present on the board or not.
+		 *
+		 * The result array will contain booleans for each piece (in order 1-N) indicating if the piece is present on the board (true)
+		 * or not (false). Keep in mind that there will be an offset of 1 between the piece type and the index (PieceType 1 will be located at index 0).
+		 *
+		 * Much faster than running \ref GetPieces if you are only interested in whether a piece exists on the board or not.
+		 *
+		 * \param player The player for which the piece placements will be returned
+		 */
+		std::array<bool, c_PieceTypes> GetPiecePlacements(PlayerId player) const;
 	private:
 		/*!
 		 * \brief Executes one piece movement, if the specified piece is on the board
@@ -116,6 +136,9 @@ namespace Alphalcazar::Game {
 		 *        If we wish to remove the piece from the array, set it to have invalid coordinates.
 		 */
 		void SetPlacedPieceCoordinates(const Piece& piece, const Coordinates& coordinates);
+
+		/// Returns the [min, max] index range at which the coordinates of the pieces of a given player are located on the \ref mPlacedPieceCoordinates array
+		std::pair<std::size_t, std::size_t> GetPlacePieceIndexRange(PlayerId playerId) const;
 
 		/// 2D array containing all tiles of the board (both perimeter and board tiles) indexed by their coordinates
 		std::array<std::array<Tile, c_PlayAreaSize>, c_PlayAreaSize> mTiles;

--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -1,14 +1,16 @@
 #pragma once
 
 #include "aliases.hpp"
+#include "Coordinates.hpp"
+#include "parameters.hpp"
+#include "Tile.hpp"
+
 #include <array>
 #include <vector>
 #include <memory>
 #include <optional>
 #include <functional>
-#include "Coordinates.hpp"
-#include "parameters.hpp"
-#include "Tile.hpp"
+#include <bitset>
 
 namespace Alphalcazar::Game {
 	class Piece;
@@ -80,16 +82,17 @@ namespace Alphalcazar::Game {
 		 */
 		std::size_t GetPieceCount(PlayerId player, bool excludePerimeter = false) const;
 		/*!
-		 * \brief Returns an array indicating if a player's piece of a certain type is present on the board or not.
+		 * \brief Returns a bitset indicating if a player's piece of a certain type is present on the board or not.
 		 *
-		 * The result array will contain booleans for each piece (in order 1-N) indicating if the piece is present on the board (true)
-		 * or not (false). Keep in mind that there will be an offset of 1 between the piece type and the index (PieceType 1 will be located at index 0).
+		 * Will return a set of \ref c_PieceTypes bits each indicating if a given piece is present on the board (bit will be set)
+		 * or not (bit will be unset). Keep in mind that there will be an offset of 1 between the piece type and the index
+		 * (The existance of PieceType 1 will be indicated by the bit at index 0).
 		 *
 		 * Much faster than running \ref GetPieces if you are only interested in whether a piece exists on the board or not.
 		 *
 		 * \param player The player for which the piece placements will be returned
 		 */
-		std::array<bool, c_PieceTypes> GetPiecePlacements(PlayerId player) const;
+		std::bitset<c_PieceTypes> GetPiecePlacements(PlayerId player) const;
 	private:
 		/*!
 		 * \brief Executes one piece movement, if the specified piece is on the board

--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -140,9 +140,6 @@ namespace Alphalcazar::Game {
 		 */
 		void SetPlacedPieceCoordinates(const Piece& piece, const Coordinates& coordinates);
 
-		/// Returns the [min, max] index range at which the coordinates of the pieces of a given player are located on the \ref mPlacedPieceCoordinates array
-		std::pair<std::size_t, std::size_t> GetPlacePieceIndexRange(PlayerId playerId) const;
-
 		/// 2D array containing all tiles of the board (both perimeter and board tiles) indexed by their coordinates
 		std::array<std::array<Tile, c_PlayAreaSize>, c_PlayAreaSize> mTiles;
 		/*!

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -222,50 +222,6 @@ namespace Alphalcazar::Game {
 		return result;
 	}
 
-	std::vector<std::pair<Coordinates, Piece>> Board::GetPieces(PlayerId player, bool excludePerimeter) const {
-		std::vector<std::pair<Coordinates, Piece>> result;
-		// We preallocate space in the vector according to the max amount of pieces that could
-		// fit in the vector if all relevant pieces were on the board. Will waste memory sometimes
-		// but memory usage is not as much of an issue as CPU usage here.
-		result.reserve(player == PlayerId::NONE ? c_PieceTypes * 2 : c_PieceTypes);
-
-		// See the docstring of \ref mPlacedPieceCoordinates for more information.
-		// We iterate only over the positions that contain the coordinates of the pieces
-		// of the specified player.
-		std::size_t min = 0;
-		std::size_t max = c_PieceTypes * 2 - 1;
-		switch (player) {
-		case PlayerId::PLAYER_ONE:
-			max = c_PieceTypes - 1;
-			break;
-		case PlayerId::PLAYER_TWO:
-			min = c_PieceTypes;
-			break;
-		default:
-			// Keep the default min/max to iterate over the complete array
-			break;
-		}
-
-		for (std::size_t i = min; i <= max; i++) {
-			auto coordinates = mPlacedPieceCoordinates[i];
-			if (coordinates.Valid()) {
-				if (excludePerimeter && coordinates.IsPerimeter()) {
-					continue;
-				}
-				if (auto* tile = GetTile(coordinates)) {
-					if (auto* piece = tile->GetPiece()) {
-						result.emplace_back(coordinates, *piece);
-					} else {
-						Utils::LogError("Placed pieces cache pointed at {} for index {}, but no piece exists at the tile at those coordinates.", coordinates, i);
-					}
-				} else {
-					Utils::LogError("Placed pieces cache pointed at {} for index {}, but no tile exists at those coordinates.", coordinates, i);
-				}
-			}
-		}
-		return result;
-	}
-
 	GameResult Board::GetResult() const {
 		std::optional<PlayerId> candidateWinner = std::nullopt;
 
@@ -315,7 +271,7 @@ namespace Alphalcazar::Game {
 	}
 
 	/// Returns the index of the \ref mPlacedPieceCoordinates array of a given piece
-	std::size_t GetPlacePieceTypeIndex(const Piece& piece) {
+	std::size_t GetPlacedPieceTypeIndex(const Piece& piece) {
 		std::size_t pieceTypeIndex = static_cast<std::size_t>(piece.GetType());
 		// The first 5 positions of the array are held by the (1-5) pieces of player one,
 		// the next 5 position by the (1-5) pieces of player 2. To get the index, we get the piece index
@@ -325,13 +281,89 @@ namespace Alphalcazar::Game {
 	}
 
 	Coordinates& Board::GetPlacedPieceCoordinates(const Piece& piece) {
-		std::size_t index = GetPlacePieceTypeIndex(piece);
+		std::size_t index = GetPlacedPieceTypeIndex(piece);
 		return mPlacedPieceCoordinates[index];
 	}
 
 	void Board::SetPlacedPieceCoordinates(const Piece& piece, const Coordinates& coordinates) {
-		std::size_t index = GetPlacePieceTypeIndex(piece);
+		std::size_t index = GetPlacedPieceTypeIndex(piece);
 		mPlacedPieceCoordinates[index] = coordinates;
+	}
+
+	std::pair<std::size_t, std::size_t> Board::GetPlacePieceIndexRange(PlayerId playerId) const {
+		// See the docstring of \ref mPlacedPieceCoordinates for more information.
+		std::size_t min = 0;
+		std::size_t max = c_PieceTypes * 2 - 1;
+		switch (playerId) {
+		case PlayerId::PLAYER_ONE:
+			max = c_PieceTypes - 1;
+			break;
+		case PlayerId::PLAYER_TWO:
+			min = c_PieceTypes;
+			break;
+		default:
+			// Keep the default min/max
+			break;
+		}
+		return std::make_pair(min, max);
+	}
+
+	std::vector<std::pair<Coordinates, Piece>> Board::GetPieces(PlayerId player, bool excludePerimeter) const {
+		std::vector<std::pair<Coordinates, Piece>> result;
+		// We preallocate space in the vector according to the max amount of pieces that could
+		// fit in the vector if all relevant pieces were on the board. Will waste memory sometimes
+		// but memory usage is not as much of an issue as CPU usage here.
+		result.reserve(player == PlayerId::NONE ? c_PieceTypes * 2 : c_PieceTypes);
+
+		auto [min, max] = GetPlacePieceIndexRange(player);
+		for (std::size_t i = min; i <= max; i++) {
+			auto coordinates = mPlacedPieceCoordinates[i];
+			if (coordinates.Valid()) {
+				if (excludePerimeter && coordinates.IsPerimeter()) {
+					continue;
+				}
+				if (auto* tile = GetTile(coordinates)) {
+					if (auto* piece = tile->GetPiece()) {
+						result.emplace_back(coordinates, *piece);
+					} else {
+						Utils::LogError("Placed pieces cache pointed at {} for index {}, but no piece exists at the tile at those coordinates.", coordinates, i);
+					}
+				} else {
+					Utils::LogError("Placed pieces cache pointed at {} for index {}, but no tile exists at those coordinates.", coordinates, i);
+				}
+			}
+		}
+		return result;
+	}
+
+	std::size_t Board::GetPieceCount(PlayerId player, bool excludePerimeter) const {
+		if (player == PlayerId::NONE) {
+			return 0;
+		}
+		std::size_t pieceCount = 0;
+		auto [min, max] = GetPlacePieceIndexRange(player);
+		for (std::size_t i = min; i <= max; i++) {
+			auto coordinates = mPlacedPieceCoordinates[i];
+			if (coordinates.Valid()) {
+				if (!excludePerimeter || !coordinates.IsPerimeter()) {
+					pieceCount++;
+				}
+			}
+		}
+		return pieceCount;
+	}
+
+	std::array<bool, c_PieceTypes> Board::GetPiecePlacements(PlayerId player) const {
+		std::array<bool, c_PieceTypes> result{};
+		if (player == PlayerId::NONE) {
+			return result;
+		}
+		auto [min, max] = GetPlacePieceIndexRange(player);
+		for (std::size_t i = min; i <= max; i++) {
+			auto coordinates = mPlacedPieceCoordinates[i];
+			result[i - min] = coordinates.Valid();
+		}
+		return result;
 	}
 
 	void Board::LoopOverTiles(std::function<void(const Coordinates& coordinates, const Tile& tile)> action) const {

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -6,6 +6,37 @@
 
 #include <algorithm>
 
+namespace {
+	/// Returns the index of the \ref mPlacedPieceCoordinates array of a given piece
+	std::size_t GetPlacedPieceTypeIndex(const Alphalcazar::Game::Piece& piece) {
+		std::size_t pieceTypeIndex = static_cast<std::size_t>(piece.GetType());
+		// The first 5 positions of the array are held by the (1-5) pieces of player one,
+		// the next 5 position by the (1-5) pieces of player 2. To get the index, we get the piece index
+		// and shift it forward by 5 for player 2 and by 0 for player 1.
+		std::size_t pieceOwnerOffset = static_cast<std::size_t>(piece.GetOwner()) - 1;
+		return pieceTypeIndex + (pieceOwnerOffset * Alphalcazar::Game::c_PieceTypes) - 1;
+	}
+
+	/// Returns the [min, max] index range at which the coordinates of the pieces of a given player are located on the \ref mPlacedPieceCoordinates array
+	std::pair<std::size_t, std::size_t> GetPlacePieceIndexRange(Alphalcazar::Game::PlayerId playerId) {
+		// See the docstring of \ref mPlacedPieceCoordinates for more information.
+		std::size_t min = 0;
+		std::size_t max = Alphalcazar::Game::c_PieceTypes * 2 - 1;
+		switch (playerId) {
+		case Alphalcazar::Game::PlayerId::PLAYER_ONE:
+			max = Alphalcazar::Game::c_PieceTypes - 1;
+			break;
+		case Alphalcazar::Game::PlayerId::PLAYER_TWO:
+			min = Alphalcazar::Game::c_PieceTypes;
+			break;
+		default:
+			// Keep the default min/max
+			break;
+		}
+		return std::make_pair(min, max);
+	}
+}
+
 namespace Alphalcazar::Game {
 	Board::Board() {}
 
@@ -270,16 +301,6 @@ namespace Alphalcazar::Game {
 		return candidateRowCompleter;
 	}
 
-	/// Returns the index of the \ref mPlacedPieceCoordinates array of a given piece
-	std::size_t GetPlacedPieceTypeIndex(const Piece& piece) {
-		std::size_t pieceTypeIndex = static_cast<std::size_t>(piece.GetType());
-		// The first 5 positions of the array are held by the (1-5) pieces of player one,
-		// the next 5 position by the (1-5) pieces of player 2. To get the index, we get the piece index
-		// and shift it forward by 5 for player 2 and by 0 for player 1.
-		std::size_t pieceOwnerOffset = static_cast<std::size_t>(piece.GetOwner()) - 1;
-		return pieceTypeIndex + (pieceOwnerOffset * c_PieceTypes) - 1;
-	}
-
 	Coordinates& Board::GetPlacedPieceCoordinates(const Piece& piece) {
 		std::size_t index = GetPlacedPieceTypeIndex(piece);
 		return mPlacedPieceCoordinates[index];
@@ -288,24 +309,6 @@ namespace Alphalcazar::Game {
 	void Board::SetPlacedPieceCoordinates(const Piece& piece, const Coordinates& coordinates) {
 		std::size_t index = GetPlacedPieceTypeIndex(piece);
 		mPlacedPieceCoordinates[index] = coordinates;
-	}
-
-	std::pair<std::size_t, std::size_t> Board::GetPlacePieceIndexRange(PlayerId playerId) const {
-		// See the docstring of \ref mPlacedPieceCoordinates for more information.
-		std::size_t min = 0;
-		std::size_t max = c_PieceTypes * 2 - 1;
-		switch (playerId) {
-		case PlayerId::PLAYER_ONE:
-			max = c_PieceTypes - 1;
-			break;
-		case PlayerId::PLAYER_TWO:
-			min = c_PieceTypes;
-			break;
-		default:
-			// Keep the default min/max
-			break;
-		}
-		return std::make_pair(min, max);
 	}
 
 	std::vector<std::pair<Coordinates, Piece>> Board::GetPieces(PlayerId player, bool excludePerimeter) const {

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -353,8 +353,8 @@ namespace Alphalcazar::Game {
 		return pieceCount;
 	}
 
-	std::array<bool, c_PieceTypes> Board::GetPiecePlacements(PlayerId player) const {
-		std::array<bool, c_PieceTypes> result{};
+	std::bitset<c_PieceTypes> Board::GetPiecePlacements(PlayerId player) const {
+		std::bitset<c_PieceTypes> result;
 		if (player == PlayerId::NONE) {
 			return result;
 		}

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -79,18 +79,19 @@ namespace Alphalcazar::Game {
 	}
 
 	std::vector<Piece> Game::GetPiecesInHand(PlayerId player) const {
-		auto boardPieces = mBoard.GetPieces(player);
 		std::vector<Piece> result;
-		result.reserve(c_PieceTypes - boardPieces.size());
-		// If all pieces are on the board, immediatelly return an empty vector
-		if (boardPieces.size() != c_PieceTypes) {
-			for (PieceType type = 1; type <= c_PieceTypes; type++) {
-				// Check if the player already has a piece of this type on the board
-				auto boardPieceIter = std::find_if(boardPieces.begin(), boardPieces.end(), [type](const std::pair<Coordinates, const Piece>& pair) {
-					return pair.second.GetType() == type;
-					});
+		if (player == PlayerId::NONE) {
+			return result;
+		}
 
-				if (boardPieceIter == boardPieces.end()) {
+		auto piecePlacements = mBoard.GetPiecePlacements(player);
+		auto placedPiecesCount = std::count(piecePlacements.begin(), piecePlacements.end(), true);
+		// If all pieces are on the board, immediatelly return an empty vector
+		if (placedPiecesCount != c_PieceTypes) {
+			result.reserve(c_PieceTypes - placedPiecesCount);
+			for (PieceType type = 1; type <= c_PieceTypes; type++) {
+				// Check if the piece type is not placed by the player on the board
+				if (!piecePlacements[type - 1]) {
 					result.emplace_back(player, type);
 				}
 			}

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -85,7 +85,7 @@ namespace Alphalcazar::Game {
 		}
 
 		auto piecePlacements = mBoard.GetPiecePlacements(player);
-		auto placedPiecesCount = std::count(piecePlacements.begin(), piecePlacements.end(), true);
+		std::size_t placedPiecesCount = piecePlacements.count();
 		// If all pieces are on the board, immediatelly return an empty vector
 		if (placedPiecesCount != c_PieceTypes) {
 			result.reserve(c_PieceTypes - placedPiecesCount);

--- a/cpp/src/game/src/game/Piece.cpp
+++ b/cpp/src/game/src/game/Piece.cpp
@@ -10,8 +10,8 @@ namespace Alphalcazar::Game {
 
 	Piece::Piece(PlayerId owner, PieceType type) noexcept
 		: mType{ type }
-		, mOwner { owner }
 		, mDirection{ Direction::NONE }
+		, mOwner { owner }
 	{}
 
 	Piece::Piece(const Piece& other) noexcept

--- a/cpp/src/game/src/game/Piece.cpp
+++ b/cpp/src/game/src/game/Piece.cpp
@@ -11,6 +11,7 @@ namespace Alphalcazar::Game {
 	Piece::Piece(PlayerId owner, PieceType type) noexcept
 		: mType{ type }
 		, mOwner { owner }
+		, mDirection{ Direction::NONE }
 	{}
 
 	Piece::Piece(const Piece& other) noexcept

--- a/cpp/src/game/tests/Board.cpp
+++ b/cpp/src/game/tests/Board.cpp
@@ -364,7 +364,9 @@ namespace Alphalcazar::Game {
 
 		EXPECT_EQ(board.GetPieces().size(), 0);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE).size(), 0);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE), 0);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO).size(), 0);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO), 0);
 		board.PlacePiece({ 0, 1 }, pieceOnePlayerOne);
 		board.PlacePiece({ 1, 0 }, pieceOnePlayerTwo);
 		board.PlacePiece({ 2, 2 }, pieceFourPlayerOne, Direction::EAST);
@@ -376,7 +378,9 @@ namespace Alphalcazar::Game {
 			auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
 			EXPECT_EQ(pieces.size(), 4);
 			EXPECT_EQ(playerOnePieces.size(), 2);
+			EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE), 2);
 			EXPECT_EQ(playerTwoPieces.size(), 2);
+			EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO), 2);
 			for (auto& [coordinates, piece] : pieces) {
 				// All pieces should be either type 1 or 4
 				EXPECT_TRUE(piece.GetType() == 4 || piece.GetType() == 1);
@@ -395,7 +399,9 @@ namespace Alphalcazar::Game {
 			auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
 			EXPECT_EQ(pieces.size(), 6);
 			EXPECT_EQ(playerOnePieces.size(), 2);
+			EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE), 2);
 			EXPECT_EQ(playerTwoPieces.size(), 4);
+			EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO), 4);
 		}
 	}
 
@@ -410,25 +416,55 @@ namespace Alphalcazar::Game {
 		board.PlacePiece({ 0, 1 }, pieceOnePlayerOne);
 		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 0);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, false).size(), 1);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE, false), 1);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, true).size(), 0);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE, true), 0);
 
 		// Place a player 2 piece on the perimeter
 		board.PlacePiece({ 2, 0 }, pieceOnePlayerTwo);
 		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 0);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, false).size(), 1);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO, false), 1);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, true).size(), 0);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO, true), 0);
 
 		// Place a player 1 piece on the center
 		board.PlacePiece({ 2, 2 }, pieceTwoPlayerOne, Direction::NORTH);
 		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 1);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, false).size(), 2);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE, false), 2);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE, true).size(), 1);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE, true), 1);
 
 		// Place a player 2 piece on a corner
 		board.PlacePiece({ 3, 3 }, pieceTwoPlayerTwo, Direction::NORTH);
 		EXPECT_EQ(board.GetPieces(PlayerId::NONE, true).size(), 2);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, false).size(), 2);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO, false), 2);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO, true).size(), 1);
+		EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_TWO, true), 1);
 		EXPECT_EQ(board.GetPieces(PlayerId::NONE, false).size(), 4);
+	}
+
+	TEST(Board, GetPiecePlacements) {
+		Board board{};
+		Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
+		Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
+
+		// Place a player 1 piece on the board
+		board.PlacePiece({ 2, 2 }, pieceOnePlayerOne, Direction::NORTH);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE).size(), 1);
+		auto playerOnePlacements = board.GetPiecePlacements(PlayerId::PLAYER_ONE);
+		for (std::size_t i = 0; i < playerOnePlacements.size(); i++) {
+			EXPECT_TRUE(i == 0 ? playerOnePlacements[i] : !playerOnePlacements[i]);
+		}
+
+		// Place a player 2 piece on the board
+		board.PlacePiece({ 2, 3 }, pieceOnePlayerTwo, Direction::NORTH);
+		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO).size(), 1);
+		auto playerTwoPlacements = board.GetPiecePlacements(PlayerId::PLAYER_TWO);
+		for (std::size_t i = 0; i < playerTwoPlacements.size(); i++) {
+			EXPECT_TRUE(i == 0 ? playerTwoPlacements[i] : !playerTwoPlacements[i]);
+		}
 	}
 }

--- a/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
@@ -71,7 +71,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	 * \param board The board of the game for which the legal movement is valid.
 	 * \param opponentBoardPieces A list of the pieces the opponent has on the board (excluding perimeter)
 	 */
-	Score GetHeuristicPlacementMoveScore(const Game::PlacementMove& move, const Game::Board& board, const std::vector<std::pair<Game::Coordinates, Game::Piece>>& opponentBoardPieces) {
+	Score GetHeuristicPlacementMoveScore(const Game::PlacementMove& move, const Game::Board& board, const std::size_t opponentBoardPieceCount) {
 		// First, we check if we have good reason to believe that the movement would result in the placed
 		// piece not even entering the board. While this can be beneficial in some very specific situations,
 		// most times it would just be a blunder, so it makes sense to assign these movements the lowest score
@@ -98,8 +98,8 @@ namespace Alphalcazar::Strategy::MinMax {
 		Score resultScore = c_PieceOnBoardScores[move.PieceType - 1];
 
 		// Check the docstring for \ref c_PusherBonusPerOpponentPiece for more information
-		if (move.PieceType == Game::c_PusherPieceType && opponentBoardPieces.size() >= 2) {
-			resultScore += static_cast<Score>(c_PusherBonusPerOpponentPiece * opponentBoardPieces.size());
+		if (move.PieceType == Game::c_PusherPieceType && opponentBoardPieceCount >= 2) {
+			resultScore += static_cast<Score>(c_PusherBonusPerOpponentPiece * opponentBoardPieceCount);
 		}
 
 		// We adjust the score based on if the piece is on the center lane (more valuable) or a lateral lane.
@@ -124,10 +124,10 @@ namespace Alphalcazar::Strategy::MinMax {
 
 	void SortLegalMovements(Game::PlayerId playerId, std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board) {
 		auto opponentId = playerId == Game::PlayerId::PLAYER_ONE ? Game::PlayerId::PLAYER_TWO : Game::PlayerId::PLAYER_ONE;
-		auto opponentBoardPieces = board.GetPieces(opponentId, true);
-		std::sort(legalMoves.begin(), legalMoves.end(), [board, opponentBoardPieces](const Game::PlacementMove& moveA, const Game::PlacementMove& moveB) {
+		std::size_t opponentBoardPieceCount = board.GetPieceCount(opponentId, true);
+		std::sort(legalMoves.begin(), legalMoves.end(), [board, opponentBoardPieceCount](const Game::PlacementMove& moveA, const Game::PlacementMove& moveB) {
 			// Sort the vector by the heuristic score of the placement moves
-			return GetHeuristicPlacementMoveScore(moveA, board, opponentBoardPieces) > GetHeuristicPlacementMoveScore(moveB, board, opponentBoardPieces);
+			return GetHeuristicPlacementMoveScore(moveA, board, opponentBoardPieceCount) > GetHeuristicPlacementMoveScore(moveB, board, opponentBoardPieceCount);
 		});
 	}
 }


### PR DESCRIPTION
`Game::GetPiecesInHand` and `SortLegalMovements` were using the `Board::GetPieces` function, when the information they actually required could be obtained through way less expensive operations.

This PR implements those cheaper operations (`Board::GetPieceCount` and `Board::GetPiecePlacements`) and replaces the uses of `Board::GetPieces` where they are not needed.

Before:
```
[2022-07-18 00:37:29.766] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-18 00:37:29.834] [info] First move at depth 2 took 61ms and calculated a score of -34
[2022-07-18 00:37:31.088] [info] First move at depth 3 took 1247ms and calculated a score of 35
[2022-07-18 00:40:35.202] [info] First move at depth 4 took 184107ms and calculated a score of -64
```

After:
```
[2022-07-18 11:48:46.761] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-18 11:48:46.830] [info] First move at depth 2 took 63ms and calculated a score of -34
[2022-07-18 11:48:48.104] [info] First move at depth 3 took 1268ms and calculated a score of 35
[2022-07-18 11:51:30.156] [info] First move at depth 4 took 162044ms and calculated a score of -64
```