### PR TITLE
Remove heap allocations in GetChainedPushMovements

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -123,10 +123,15 @@ namespace Alphalcazar::Game {
 		 * Each chained movement will be described as a pair of the source tile from which a piece needs to be moved from and
 		 * the target tile it needs to be moved to.
 		 *
-		 * \note The list will be returned in the order the movements are supposed to be executed (with the last piece of the chain
+		 * \note The order of the array describes the order the movements are supposed to be executed (with the last piece of the chain
 		 * first and the movement of the pushing piece last)
+		 *
+		 * \returns A pair of [chainedMovements, chainedMovementsCount], where the first item is a fixed-size array populated from the back, and
+		 *          the second argument a counter describing how many valid movements exist in the array.
+		 *          For example, a count of 2 will indicate the array has the following structure: [invalid, invalid, invalid, movement_1, movement_2].
+		 *          The array is structured in this unusual way due to performance reasons.
 		 */
-		std::vector<MovementDescription> GetChainedPushMovements(const Coordinates& sourceCoordinates, Direction direction);
+		std::pair<std::array<Board::MovementDescription, c_PlayAreaSize>, std::size_t> GetChainedPushMovements(const Coordinates& sourceCoordinates, Direction direction);
 
 		/// Executes a specified function for every tile of this board
 		void LoopOverTiles(std::function<void(const Coordinates& coordinates, const Tile& tile)> action) const;


### PR DESCRIPTION
There's no good reason to do these unnecesary allocations when we know that the vector size will be capped at 5. Also inserting at the beginning of the vector each iteration is a big no-no.

Before:
```
[2022-07-18 11:48:46.761] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-18 11:48:46.830] [info] First move at depth 2 took 63ms and calculated a score of -34
[2022-07-18 11:48:48.104] [info] First move at depth 3 took 1268ms and calculated a score of 35
[2022-07-18 11:51:30.156] [info] First move at depth 4 took 162044ms and calculated a score of -64
```

After:
```
[2022-09-01 19:42:01.428] [info] First move at depth 1 took 1ms and calculated a score of 0
[2022-09-01 19:42:01.499] [info] First move at depth 2 took 69ms and calculated a score of -34
[2022-09-01 19:42:02.622] [info] First move at depth 3 took 1121ms and calculated a score of 35
[2022-09-01 19:44:51.337] [info] First move at depth 4 took 168714ms and calculated a score of -64
```