### PR TITLE
Remove Coordinates/Board integrity checks in Release

### DIFF
--- a/cpp/src/game/include/game/aliases.hpp
+++ b/cpp/src/game/include/game/aliases.hpp
@@ -6,7 +6,7 @@ namespace Alphalcazar::Game {
 	using BoardMovesCount = std::uint16_t;
 	using PieceType = std::uint8_t;
 	constexpr PieceType c_InvalidPieceType = 0;
-	using Coordinate = std::int32_t; // (+-128 should be more than enough for a 3x3 board)
+	using Coordinate = std::int32_t;
 
 	enum class GameResult : std::uint8_t {
 		NONE = 0,

--- a/cpp/src/game/include/game/aliases.hpp
+++ b/cpp/src/game/include/game/aliases.hpp
@@ -6,7 +6,7 @@ namespace Alphalcazar::Game {
 	using BoardMovesCount = std::uint16_t;
 	using PieceType = std::uint8_t;
 	constexpr PieceType c_InvalidPieceType = 0;
-	using Coordinate = std::int8_t; // (+-128 should be more than enough for a 3x3 board)
+	using Coordinate = std::int32_t; // (+-128 should be more than enough for a 3x3 board)
 
 	enum class GameResult : std::uint8_t {
 		NONE = 0,

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -1,6 +1,7 @@
 #include "game/Coordinates.hpp"
 
 #include <util/Log.hpp>
+#include "safety_checks.hpp"
 
 namespace Alphalcazar::Game {
 
@@ -27,70 +28,41 @@ namespace Alphalcazar::Game {
 		DIR_OFFSETS(-1, 1), // NORTH_WEST
 	}};
 
-	bool Coordinates::operator==(const Coordinates& coord) const {
-		return x == coord.x && y == coord.y;
-	}
-
-	bool Coordinates::operator!=(const Coordinates& coord) const {
-		return x != coord.x || y != coord.y;
-	}
-
-	bool Coordinates::IsPlayArea() const {
-		return x >= 0 && x < c_PlayAreaSize&& y >= 0 && y < c_PlayAreaSize && !IsCorner();
-	}
-
-	bool Coordinates::IsPerimeter() const {
-		return x == 0 || x == c_PlayAreaSize - 1 || y == 0 || y == c_PlayAreaSize - 1;
-	}
-
-	bool Coordinates::IsCenter() const {
-		return x == c_CenterCoordinate && y == c_CenterCoordinate;
-	}
-
-	bool Coordinates::IsOnCenterLane() const {
-		return x == c_CenterCoordinate || y == c_CenterCoordinate;
-	}
-
-	bool Coordinates::IsCorner() const {
-		return (x == 0 || x == c_PlayAreaSize - 1) && (y == 0 || y == c_PlayAreaSize - 1);
-	}
-
-	bool Coordinates::IsBoardCorner() const {
-		return (x == 1 || x == c_BoardSize) && (y == 1 || y == c_BoardSize);
-	}
-
 	Direction Coordinates::GetLegalPlacementDirection() const {
-		if (IsPerimeter()) {
-			if (x == 0) {
-				return Direction::EAST;
-			} else if (x == c_PlayAreaSize - 1) {
-				return Direction::WEST;
-			} else if (y == 0) {
-				return Direction::NORTH;
-			} else if (y == c_PlayAreaSize - 1) {
-				return Direction::SOUTH;
+		if (c_CoordinatesIntegrityChecks) {
+			if (!IsPerimeter()) {
+				// Pieces cannot be placed on non-perimeter tiles.
+				return Direction::NONE;
 			}
 		}
-		// Pieces cannot be placed on non-perimeter tiles.
-		return Direction::NONE;
+		if (x == 0) {
+			return Direction::EAST;
+		} else if (x == c_PlayAreaSize - 1) {
+			return Direction::WEST;
+		} else if (y == 0) {
+			return Direction::NORTH;
+		} else {
+			return Direction::SOUTH;
+		}
 	}
 
 	Coordinates Coordinates::GetCoordinateInDirection(Direction direction, Coordinate distance) const {
-		if (!Valid()) {
-			Utils::LogError("Tried to get coordinate offset from an invalid coordinate");
-			return Invalid();
-		}
-		if (direction == Direction::NONE) {
-			Utils::LogError("Tried getting a coordinate offset into an invalid direction");
-			return Invalid();
+		if constexpr (c_CoordinatesIntegrityChecks) {
+			if (!Valid()) {
+				Utils::LogError("Tried to get coordinate offset from an invalid coordinate");
+				return Invalid();
+			}
+			if (direction == Direction::NONE) {
+				Utils::LogError("Tried getting a coordinate offset into an invalid direction");
+				return Invalid();
+			}
 		}
 
-		auto& offset = c_DirectionOffsets[static_cast<std::size_t>(direction)];
-		return Coordinates{ static_cast<Coordinate>(x + offset.first * distance), static_cast<Coordinate>(y + offset.second * distance) };
-	}
-
-	bool Coordinates::Valid() const {
-		return x != c_InvalidCoordinate && y != c_InvalidCoordinate;
+		std::size_t directionOffset = static_cast<std::size_t>(direction);
+		auto& offset = c_DirectionOffsets[directionOffset];
+		Coordinate xOffset = offset.first * distance;
+		Coordinate yOffset = offset.second * distance;
+		return Coordinates{ x + xOffset, y + yOffset };
 	}
 
 	Coordinates Coordinates::Invalid() {

--- a/cpp/src/game/src/game/safety_checks.hpp
+++ b/cpp/src/game/src/game/safety_checks.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace Alphalcazar::Game {
+	/*!
+	 * \brief Whether the \ref Coordinates struct should check for the integrity of its data.
+	 *
+	 * If false, some assert-like checks in the \ref Coordinates class will be skipped that could assert
+	 * invalid data returned from its function calls.
+	 */
+#if defined _DEBUG
+	constexpr bool c_CoordinatesIntegrityChecks = true;
+#else
+	constexpr bool c_CoordinatesIntegrityChecks = false;
+#endif
+
+	/*!
+	 * \brief Whether the integrity of the piece placement information in the \ref Board class should be checked.
+	 *
+	 * If false, all information in the \ref Board class will be considered to be valid, and some null pointer checks will
+	 * be skipped. This is meant to avoid unnecesary code branching in Release mode, but keep those checks while developing in
+	 * Debug mode to quickly discover bugs through meaningful error logs rather than crashes.
+	 */
+#if defined _DEBUG
+	constexpr bool c_BoardPiecePlacementIntegrityChecks = true;
+#else
+	constexpr bool c_BoardPiecePlacementIntegrityChecks = false;
+#endif
+}


### PR DESCRIPTION
These checks were creating unnecesary branching and instruction-level cache misses. We still want to keep them in debug mode though.

Also inlines several functions of the `Coordinates` struct due to their simplicity and frequent invocations.

Before:
```
[2022-07-18 00:37:29.766] [info] First move at depth 1 took 3ms and calculated a score of 0
[2022-07-18 00:37:29.834] [info] First move at depth 2 took 61ms and calculated a score of -34
[2022-07-18 00:37:31.088] [info] First move at depth 3 took 1247ms and calculated a score of 35
[2022-07-18 00:40:35.202] [info] First move at depth 4 took 184107ms and calculated a score of -64
```

After:
```
[2022-09-01 20:07:37.529] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-09-01 20:07:37.581] [info] First move at depth 2 took 49ms and calculated a score of -34
[2022-09-01 20:07:38.419] [info] First move at depth 3 took 836ms and calculated a score of 35
[2022-09-01 20:10:03.578] [info] First move at depth 4 took 145158ms and calculated a score of -64
```