### PR TITLE
Change Tile::GetPiece to return a reference instead of a pointer

### DIFF
--- a/cpp/src/game/include/game/Tile.hpp
+++ b/cpp/src/game/include/game/Tile.hpp
@@ -13,17 +13,13 @@ namespace Alphalcazar::Game {
 	 */
 	class Tile {
 	public:
-		Tile();
-		Tile(const Tile& other);
-		~Tile();
-
 		/// Places a piece on this tile
 		void PlacePiece(const Piece& piece);
 		/// Removes the piece that was placed on this tile, if any
 		void RemovePiece();
-		/// Returns the piece that is currently placed on this tile, or std::nullopt if no piece is on this tile
-		const Piece* GetPiece() const;
-		Piece* GetPiece();
+		/// Returns the piece that is currently placed on this tile, or an invalid piece if no piece exists on this tile
+		const Piece& GetPiece() const;
+		Piece& GetPiece();
 
 		bool HasPiece() const;
 	private:

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -57,7 +57,7 @@ namespace Alphalcazar::Game {
 			}
 		}
 		tile->PlacePiece(piece);
-		tile->GetPiece()->SetMovementDirection(coordinates.GetLegalPlacementDirection());
+		tile->GetPiece().SetMovementDirection(coordinates.GetLegalPlacementDirection());
 
 		SetPlacedPieceCoordinates(piece, coordinates);
 	}
@@ -70,7 +70,7 @@ namespace Alphalcazar::Game {
 			}
 		}
 		tile->PlacePiece(piece);
-		tile->GetPiece()->SetMovementDirection(direction);
+		tile->GetPiece().SetMovementDirection(direction);
 
 		SetPlacedPieceCoordinates(piece, coordinates);
 	}
@@ -81,16 +81,16 @@ namespace Alphalcazar::Game {
 		const Coordinates& originCoordinates = GetPlacedPieceCoordinates(piece);
 		if (originCoordinates.Valid()) {
 			Tile* originTile = GetTile(originCoordinates);
-			Piece* originPiece = originTile->GetPiece();
+			const Piece& originPiece = originTile->GetPiece();
 
-			auto direction = originPiece->GetMovementDirection();
+			auto direction = originPiece.GetMovementDirection();
 			Coordinates targetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 1);
 			if (Tile* targetTile = GetTile(targetCoordinates)) {
-				Piece* targetTilePiece = targetTile->GetPiece();
-				if (targetTilePiece == nullptr) {
+				const Piece& targetTilePiece = targetTile->GetPiece();
+				if (!targetTilePiece.IsValid()) {
 					MovePiece(*originTile, *targetTile, targetCoordinates);
 					movedPieces++;
-				} else if (originPiece->IsPusher()) {
+				} else if (originPiece.IsPusher()) {
 					auto [chainedMovements, chainedMovementsCount] = GetChainedPushMovements(originCoordinates, direction);
 					// We execute the chained push movements in order
 					for(std::size_t i = chainedMovements.size() - chainedMovementsCount; i < chainedMovements.size(); ++i) {
@@ -104,7 +104,7 @@ namespace Alphalcazar::Game {
 						}
 						movedPieces++;
 					}
-				} else if (targetTilePiece->IsPushable() && !originPiece->IsPushable()) {
+				} else if (targetTilePiece.IsPushable() && !originPiece.IsPushable()) {
 					auto pushTargetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 2);
 					auto* pushTargetTile = GetTile(pushTargetCoordinates);
 					// A non-pushing piece cannot push a pushable piece if there is a piece on the tile
@@ -164,21 +164,22 @@ namespace Alphalcazar::Game {
 	}
 
 	void Board::MovePiece(Tile& source, Tile& target, const Coordinates& targetCoordinates) {
-		if (auto* piece = source.GetPiece()) {
+		if (source.HasPiece()) {
+			const auto& piece = source.GetPiece();
 			// A piece that moves or is moved to a perimeter tile gets removed from play immediatelly
 			if (!targetCoordinates.IsPerimeter()) {
-				SetPlacedPieceCoordinates(*piece, targetCoordinates);
-				target.PlacePiece(*piece);
+				SetPlacedPieceCoordinates(piece, targetCoordinates);
+				target.PlacePiece(piece);
 			} else {
-				SetPlacedPieceCoordinates(*piece, Coordinates::Invalid());
+				SetPlacedPieceCoordinates(piece, Coordinates::Invalid());
 			}
 			source.RemovePiece();
 		}
 	}
 
 	void Board::RemovePiece(Tile& tile) {
-		if (auto* piece = tile.GetPiece()) {
-			SetPlacedPieceCoordinates(*piece, Coordinates::Invalid());
+		if (tile.HasPiece()) {
+			SetPlacedPieceCoordinates(tile.GetPiece(), Coordinates::Invalid());
 			tile.RemovePiece();
 		}
 	}
@@ -295,13 +296,13 @@ namespace Alphalcazar::Game {
 		// both players on it.
 		std::optional<PlayerId> candidateRowCompleter = std::nullopt;
 
-		for (Coordinate distance = 0; distance < length; distance++) {
+		for (Coordinate distance = 0; distance < length; ++distance) {
 			Coordinates nextCoordinate = startCoordinate.GetCoordinateInDirection(direction, distance);
-			if (auto piece = mTiles[nextCoordinate.x][nextCoordinate.y].GetPiece()) {
+			if (const auto& piece = mTiles[nextCoordinate.x][nextCoordinate.y].GetPiece(); piece.IsValid()) {
 				if (candidateRowCompleter == std::nullopt) {
 					// We appoint the owner of the first piece we find as our candidate
-					candidateRowCompleter = piece->GetOwner();
-				} else if (candidateRowCompleter != piece->GetOwner()) {
+					candidateRowCompleter = piece.GetOwner();
+				} else if (candidateRowCompleter != piece.GetOwner()) {
 					// If we find a piece that doesn't belong to the already determined candidate for completing the row
 					// we return nullopt as we know the row won't be complete
 					return std::nullopt;
@@ -343,13 +344,11 @@ namespace Alphalcazar::Game {
 					if (!tile) {
 						Utils::LogError("Placed pieces cache pointed at {} for index {}, but no tile exists at those coordinates.", coordinates, i);
 					}
-				}
-				if constexpr (c_BoardPiecePlacementIntegrityChecks) {
 					if (!tile->HasPiece()) {
 						Utils::LogError("Placed pieces cache pointed at {} for index {}, but no piece exists at the tile at those coordinates.", coordinates, i);
 					}
 				}
-				result.emplace_back(coordinates, *tile->GetPiece());
+				result.emplace_back(coordinates, tile->GetPiece());
 			}
 		}
 		return result;

--- a/cpp/src/game/src/game/Tile.cpp
+++ b/cpp/src/game/src/game/Tile.cpp
@@ -1,19 +1,14 @@
 #include "game/Piece.hpp"
 #include "game/Tile.hpp"
+#include "safety_checks.hpp"
 #include <util/Log.hpp>
 
 namespace Alphalcazar::Game {
-	Tile::Tile() {}
-
-	Tile::Tile(const Tile& other)
-		: mPiece { other.mPiece }
-	{}
-
-	Tile::~Tile() {}
-
 	void Tile::PlacePiece(const Piece& piece) {
-		if (mPiece.IsValid()) {
-			Utils::LogError("Tried placing a piece on a tile that already had a piece on it.");
+		if constexpr (c_BoardPiecePlacementIntegrityChecks) {
+			if (mPiece.IsValid()) {
+				Utils::LogError("Tried placing a piece on a tile that already had a piece on it.");
+			}
 		}
 		mPiece = piece;
 	}
@@ -27,17 +22,11 @@ namespace Alphalcazar::Game {
 		return mPiece.IsValid();
 	}
 
-	const Piece* Tile::GetPiece() const {
-		if (mPiece.IsValid()) {
-			return &mPiece;
-		}
-		return nullptr;
+	const Piece& Tile::GetPiece() const {
+		return mPiece;
 	}
 
-	Piece* Tile::GetPiece() {
-		if (mPiece.IsValid()) {
-			return &mPiece;
-		}
-		return nullptr;
+	Piece& Tile::GetPiece() {
+		return mPiece;
 	}
 }

--- a/cpp/src/game/tests/Board.cpp
+++ b/cpp/src/game/tests/Board.cpp
@@ -31,7 +31,7 @@ namespace Alphalcazar::Game {
 				pieceIndex = 0;
 			}
 			board.PlacePiece(coordinates, piece);
-			EXPECT_EQ(*board.GetTile(coordinates)->GetPiece(), piece);
+			EXPECT_EQ(board.GetTile(coordinates)->GetPiece(), piece);
 		}
 		// Board should still be empty as we have only placed on perimeter tiles
 		EXPECT_EQ(board.IsFull(), false);
@@ -157,11 +157,11 @@ namespace Alphalcazar::Game {
 		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
 		EXPECT_EQ(executedMoves, 4);
 
-		EXPECT_EQ(*board.GetTile(1, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 5));
-		EXPECT_EQ(board.GetTile(3, 0)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(0, 2)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(3, 1)->GetPiece(), nullptr);
+		EXPECT_EQ(board.GetTile(1, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 5));
+		EXPECT_FALSE(board.GetTile(3, 0)->HasPiece());
+		EXPECT_FALSE(board.GetTile(0, 2)->HasPiece());
+		EXPECT_FALSE(board.GetTile(2, 2)->HasPiece());
+		EXPECT_FALSE(board.GetTile(3, 1)->HasPiece());
 		EXPECT_EQ(board.GetPieces().size(), 1);
 	}
 
@@ -177,8 +177,8 @@ namespace Alphalcazar::Game {
 		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
 		EXPECT_EQ(executedMoves, 0);
 
-		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
-		EXPECT_EQ(*board.GetTile(2, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PushablePieceType));
+		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
+		EXPECT_EQ(board.GetTile(2, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PushablePieceType));
 		EXPECT_EQ(board.GetPieces().size(), 2);
 	}
 
@@ -207,15 +207,15 @@ namespace Alphalcazar::Game {
 		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 		EXPECT_EQ(executedMoves, 6);
 
-		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 2));
-		EXPECT_EQ(board.GetTile(2, 0)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(1, 1)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(1, 2)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(1, 4)->GetPiece(), nullptr);
-		EXPECT_EQ(*board.GetTile(3, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 3));
-		EXPECT_EQ(*board.GetTile(3, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PushablePieceType));
-		EXPECT_EQ(*board.GetTile(1, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 5));
-		EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
+		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 2));
+		EXPECT_FALSE(board.GetTile(2, 0)->HasPiece());
+		EXPECT_FALSE(board.GetTile(1, 1)->HasPiece());
+		EXPECT_FALSE(board.GetTile(1, 2)->HasPiece());
+		EXPECT_FALSE(board.GetTile(1, 4)->HasPiece());
+		EXPECT_EQ(board.GetTile(3, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 3));
+		EXPECT_EQ(board.GetTile(3, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PushablePieceType));
+		EXPECT_EQ(board.GetTile(1, 3)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 5));
+		EXPECT_EQ(board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
 		EXPECT_EQ(board.GetPieces().size(), 5);
 	}
 
@@ -234,9 +234,9 @@ namespace Alphalcazar::Game {
 		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 		EXPECT_EQ(executedMoves, 5);
 
-		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
-		EXPECT_EQ(*board.GetTile(3, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 3));
-		EXPECT_EQ(board.GetTile(4, 2)->GetPiece(), nullptr);
+		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
+		EXPECT_EQ(board.GetTile(3, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 3));
+		EXPECT_FALSE(board.GetTile(4, 2)->HasPiece());
 		EXPECT_EQ(board.GetPieces().size(), 2);
 	}
 
@@ -254,8 +254,8 @@ namespace Alphalcazar::Game {
 			auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 			EXPECT_EQ(executedMoves, 4);
 
-			EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
-			EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PusherPieceType));
+			EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
+			EXPECT_EQ(board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PusherPieceType));
 
 			EXPECT_EQ(board.GetPieces().size(), 2);
 		}
@@ -267,8 +267,8 @@ namespace Alphalcazar::Game {
 			auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
 			EXPECT_EQ(executedMoves, 2);
 
-			EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), nullptr);
-			EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
+			EXPECT_FALSE(board.GetTile(2, 2)->HasPiece());
+			EXPECT_EQ(board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
 
 			EXPECT_EQ(board.GetPieces().size(), 1);
 		}
@@ -303,12 +303,12 @@ namespace Alphalcazar::Game {
 		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 		EXPECT_EQ(executedMoves, 8);
 
-		EXPECT_EQ(*board.GetTile(1, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 1));
-		EXPECT_EQ(*board.GetTile(2, 3)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 2));
-		EXPECT_EQ(*board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 5));
-		EXPECT_EQ(*board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PusherPieceType));
-		EXPECT_EQ(board.GetTile(2, 4)->GetPiece(), nullptr);
-		EXPECT_EQ(board.GetTile(4, 1)->GetPiece(), nullptr);
+		EXPECT_EQ(board.GetTile(1, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 1));
+		EXPECT_EQ(board.GetTile(2, 3)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 2));
+		EXPECT_EQ(board.GetTile(2, 1)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 5));
+		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, c_PusherPieceType));
+		EXPECT_FALSE(board.GetTile(2, 4)->HasPiece());
+		EXPECT_FALSE(board.GetTile(4, 1)->HasPiece());
 
 		EXPECT_EQ(board.GetPieces().size(), 4);
 	}
@@ -349,10 +349,10 @@ namespace Alphalcazar::Game {
 		EXPECT_NE(boardCopy.GetTile(2, 0), nullptr);
 		EXPECT_NE(boardCopy.GetTile(2, 2), nullptr);
 
-		EXPECT_EQ(*boardCopy.GetTile(0, 1)->GetPiece(), pieceOne);
-		EXPECT_EQ(*boardCopy.GetTile(1, 0)->GetPiece(), pieceTwo);
-		EXPECT_EQ(*boardCopy.GetTile(2, 0)->GetPiece(), pieceThree);
-		EXPECT_EQ(*boardCopy.GetTile(2, 2)->GetPiece(), pieceFour);
+		EXPECT_EQ(boardCopy.GetTile(0, 1)->GetPiece(), pieceOne);
+		EXPECT_EQ(boardCopy.GetTile(1, 0)->GetPiece(), pieceTwo);
+		EXPECT_EQ(boardCopy.GetTile(2, 0)->GetPiece(), pieceThree);
+		EXPECT_EQ(boardCopy.GetTile(2, 2)->GetPiece(), pieceFour);
 	}
 
 	TEST(Board, GetBoardPieces) {

--- a/cpp/src/game/tests/Game.cpp
+++ b/cpp/src/game/tests/Game.cpp
@@ -71,8 +71,8 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(game.GetState().Turn, 0);
 		EXPECT_EQ(game.GetState().FirstMoveExecuted, true);
 		EXPECT_EQ(game.GetActivePlayer(), PlayerId::PLAYER_TWO);
-		EXPECT_EQ(game.GetBoard().GetTile(0, 3)->GetPiece()->GetOwner(), PlayerId::PLAYER_ONE);
-		EXPECT_EQ(game.GetBoard().GetTile(0, 3)->GetPiece()->GetType(), 3);
+		EXPECT_EQ(game.GetBoard().GetTile(0, 3)->GetPiece().GetOwner(), PlayerId::PLAYER_ONE);
+		EXPECT_EQ(game.GetBoard().GetTile(0, 3)->GetPiece().GetType(), 3);
 
 		// After playing the second placement move, we expect the end turn phase to have been
 		// evaluated and the pieces to have moved.
@@ -82,11 +82,11 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(game.GetActivePlayer(), PlayerId::PLAYER_TWO);
 		EXPECT_FALSE(game.GetBoard().GetTile(0, 3)->HasPiece());
 		EXPECT_FALSE(game.GetBoard().GetTile(2, 0)->HasPiece());
-		EXPECT_EQ(game.GetBoard().GetTile(1, 3)->GetPiece()->GetType(), 3);
-		EXPECT_EQ(game.GetBoard().GetTile(2, 1)->GetPiece()->GetType(), 5);
+		EXPECT_EQ(game.GetBoard().GetTile(1, 3)->GetPiece().GetType(), 3);
+		EXPECT_EQ(game.GetBoard().GetTile(2, 1)->GetPiece().GetType(), 5);
 
 		// We also expect the piece spawned from move 2 to belong to player 2
-		EXPECT_EQ(game.GetBoard().GetTile(2, 1)->GetPiece()->GetOwner(), PlayerId::PLAYER_TWO);
+		EXPECT_EQ(game.GetBoard().GetTile(2, 1)->GetPiece().GetOwner(), PlayerId::PLAYER_TWO);
 
 		// On the next turn, we expect the first placement move to be played by player 2,
 		// as the player with initiative should have switched
@@ -94,7 +94,7 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(game.GetState().Turn, 1);
 		EXPECT_EQ(game.GetActivePlayer(), PlayerId::PLAYER_ONE);
 		EXPECT_EQ(game.GetState().FirstMoveExecuted, true);
-		EXPECT_EQ(game.GetBoard().GetTile(0, 1)->GetPiece()->GetOwner(), PlayerId::PLAYER_TWO);
+		EXPECT_EQ(game.GetBoard().GetTile(0, 1)->GetPiece().GetOwner(), PlayerId::PLAYER_TWO);
 		EXPECT_EQ(game.GetState().Turn, 1);
 		EXPECT_EQ(game.GetState().FirstMoveExecuted, true);
 	}

--- a/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/LegalMovements.cpp
@@ -78,15 +78,17 @@ namespace Alphalcazar::Strategy::MinMax {
 		if (move.PieceType != Game::c_PusherPieceType) {
 			auto placementDirection = move.Coordinates.GetLegalPlacementDirection();
 			auto pieceTargetCoordinate = move.Coordinates.GetCoordinateInDirection(placementDirection, 1);
-			if (auto* pieceTargetTilePiece = board.GetTile(pieceTargetCoordinate)->GetPiece()) {
+			auto* pieceTargetTile = board.GetTile(pieceTargetCoordinate);
+			if (pieceTargetTile->HasPiece()) {
 				// There's a piece on the tile that our piece is looking at
 				// We check if we can expect the piece to be gone before our piece moves
 				// or if the piece can be pushed by us
-				if (!pieceTargetTilePiece->IsPushable()) {
-					auto blockingPieceTargetCoordinate = pieceTargetCoordinate.GetCoordinateInDirection(pieceTargetTilePiece->GetMovementDirection(), 1);
+				auto& pieceTargetTilePiece = pieceTargetTile->GetPiece();
+				if (!pieceTargetTilePiece.IsPushable()) {
+					auto blockingPieceTargetCoordinate = pieceTargetCoordinate.GetCoordinateInDirection(pieceTargetTilePiece.GetMovementDirection(), 1);
 					// We check if the target piece moves after us, or if it will attempt to move to the position where we have placed
 					// the piece, causing its movement to be blocked
-					if (pieceTargetTilePiece->GetType() > move.PieceType || blockingPieceTargetCoordinate == move.Coordinates) {
+					if (pieceTargetTilePiece.GetType() > move.PieceType || blockingPieceTargetCoordinate == move.Coordinates) {
 						return 0;
 					}
 				}

--- a/cpp/src/strategies/random/tests/RandomStrategy.cpp
+++ b/cpp/src/strategies/random/tests/RandomStrategy.cpp
@@ -31,7 +31,7 @@ namespace Alphalcazar::Strategy::Random {
 			// (1 if the entering piece of the first player blocked the entrance of the piece of the second player)
 			auto pieces = 0;
 			for (const auto* tile : board.GetTiles()) {
-				if (tile->GetPiece()) {
+				if (tile->HasPiece()) {
 					pieces += 1;
 				}
 			}


### PR DESCRIPTION
There's no reason to return a pointer since we can simply check for the invalid state of `Piece` to see if a piece exists on the given tile. Furthermore (for the future), the `Tile` class does not any kind of value to the semantics of the project and just creates overhead, it should be removed in the future.

Also, removes the user-defined constructors and destructors from the `Tile` class to avoid the compiler to inline them.

Before:
```
[2022-09-03 14:17:09.061] [info] First move at depth 1 took 11ms and calculated a score of 0
[2022-09-03 14:17:09.098] [info] First move at depth 2 took 30ms and calculated a score of -34
[2022-09-03 14:17:09.774] [info] First move at depth 3 took 672ms and calculated a score of 35
[2022-09-03 14:18:58.248] [info] First move at depth 4 took 108473ms and calculated a score of -64
```

After:
```
[2022-09-03 14:14:39.163] [info] First move at depth 1 took 8ms and calculated a score of 0
[2022-09-03 14:14:39.197] [info] First move at depth 2 took 28ms and calculated a score of -34
[2022-09-03 14:14:39.718] [info] First move at depth 3 took 518ms and calculated a score of 35
[2022-09-03 14:16:19.202] [info] First move at depth 4 took 99462ms and calculated a score of -64
```