### PR TITLE
Replace upper-bound vectors returned by Board/Game with static vectors

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -96,10 +96,6 @@ namespace Alphalcazar::Game {
 		 */
 		std::bitset<c_PieceTypes> GetPiecePlacements(PlayerId player) const;
 	private:
-		template<std::size_t Capacity>
-		Utils::StaticVector<std::pair<Coordinates, Piece>, Capacity> GetPiecesInternal(PlayerId player, bool excludePerimeter = false) const {
-
-		}
 		/*!
 		 * \brief Executes one piece movement, if the specified piece is on the board
 		 *
@@ -145,6 +141,16 @@ namespace Alphalcazar::Game {
 		 *        If we wish to remove the piece from the array, set it to have invalid coordinates.
 		 */
 		void SetPlacedPieceCoordinates(const Piece& piece, const Coordinates& coordinates);
+
+		/*!
+		 * \brief Loops over a [min, max] range of piece placements, fetches the corresponding piece and executed a custom action for each of them.
+		 *
+		 * \param min The min of the range of the piece placements.
+		 * \param min The max of the range of the piece placements.
+		 * \param excludePerimeter Whether to skip executing the action for pieces placed on the perimeter of the board.
+		 * \param action The action to execute for every piece.
+		 */
+		void FetchPiecesFromIndexRange(std::size_t min, std::size_t max, bool excludePerimeter, std::function<void(const Coordinates& coordinates, const Piece& piece)> action) const;
 
 		/// 2D array containing all tiles of the board (both perimeter and board tiles) indexed by their coordinates
 		std::array<std::array<Tile, c_PlayAreaSize>, c_PlayAreaSize> mTiles;

--- a/cpp/src/game/include/game/Game.hpp
+++ b/cpp/src/game/include/game/Game.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 #include <memory>
 #include "aliases.hpp"
-#include "util/CallbackHandler.hpp"
 #include "Board.hpp"
+#include <util/StaticVector.hpp>
 
 namespace Alphalcazar::Game {
 	class Strategy;
@@ -62,15 +61,15 @@ namespace Alphalcazar::Game {
 		const Board& GetBoard() const;
 
 		/*!
-		 * \brief Returns a list of legal placement moves for the current player.
+		 * \brief Returns a \ref StaticVector of legal placement moves for the current player.
 		 *
 		 * A legal placement moves is defined as any combination of free perimeter tile and
 		 * available piece (in hand) the player has available.
 		 */
-		std::vector<PlacementMove> GetLegalMoves(PlayerId player) const;
+		Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount> GetLegalMoves(PlayerId player) const;
 
 		/// Returns a list of all pieces that the specified player has in hand (are not placed on the board)
-		std::vector<Piece> GetPiecesInHand(PlayerId player) const;
+		Utils::StaticVector<Piece, c_PieceTypes> GetPiecesInHand(PlayerId player) const;
 	private:
 		/// Exchange the player with initiative
 		void SwapPlayerWithInitiative();

--- a/cpp/src/game/include/game/PlacementMove.hpp
+++ b/cpp/src/game/include/game/PlacementMove.hpp
@@ -7,7 +7,7 @@
 
 namespace Alphalcazar::Game {
 	/*!
-  	 * \brief Data structure with the minimnal information needed to uniquely represent a placement move.
+  	 * \brief Data structure with the minimal information needed to uniquely represent a placement move.
 	 *
 	 * A placement move is defined as the action a player takes at the start of each turn,
 	 * where they take a piece they have in hand and place it on the perimeter of the board, facing
@@ -21,7 +21,7 @@ namespace Alphalcazar::Game {
 		Coordinates Coordinates;
 		PieceType PieceType;
 
-		/// Returns whether the placement move isvalid
+		/// Returns whether the placement move is valid
 		bool Valid() const;
 		bool operator==(const PlacementMove& other) const;
 	};

--- a/cpp/src/game/include/game/Strategy.hpp
+++ b/cpp/src/game/include/game/Strategy.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "aliases.hpp"
-
-#include <vector>
+#include "parameters.hpp"
+#include <util/StaticVector.hpp>
 
 namespace Alphalcazar::Game {
 	class Game;
@@ -28,6 +28,6 @@ namespace Alphalcazar::Game {
 		 * 
 		 * \returns The move to be executed.
 		 */
-		virtual PlacementMove Execute(PlayerId playerId, const std::vector<PlacementMove>& legalMoves, const Game& game) = 0;
+		virtual PlacementMove Execute(PlayerId playerId, const Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount>& legalMoves, const Game& game) = 0;
 	};
 }

--- a/cpp/src/game/include/game/parameters.hpp
+++ b/cpp/src/game/include/game/parameters.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include "aliases.hpp"
+#include <cstddef>
 
 namespace Alphalcazar::Game {
 	/// The amount of pieces / piece types each player has in total
@@ -25,8 +26,14 @@ namespace Alphalcazar::Game {
 	/// The coordinate at the center of the board. This value will only have significance for odd board sizes.
 	constexpr Coordinate c_CenterCoordinate = c_BoardSize / 2 + 1;
 
+	/// The amount of tiles that make up the play area of the board. Is c_PlayAreaSize^2 minus the four corners
+	constexpr Coordinate c_PlayAreaTileCount = c_PlayAreaSize * c_PlayAreaSize - 4;
+
 	/// The amount of tiles that make up the perimeter of the board
 	constexpr Coordinate c_PerimeterTileCount = c_BoardSize * 4;
+
+	/// The maximum amount of legal moves that a player can have on their turn
+	constexpr std::size_t c_MaxLegalMovesCount = c_PieceTypes * c_PerimeterTileCount;
 
 	/*!
 	 * \brief Whether the game ends in a draw condition when both players complete a row.

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -78,8 +78,8 @@ namespace Alphalcazar::Game {
 		mBoard.PlacePiece(move.Coordinates, piece);
 	}
 
-	std::vector<Piece> Game::GetPiecesInHand(PlayerId player) const {
-		std::vector<Piece> result;
+	Utils::StaticVector<Piece, c_PieceTypes> Game::GetPiecesInHand(PlayerId player) const {
+		Utils::StaticVector<Piece, c_PieceTypes> result;
 		if (player == PlayerId::NONE) {
 			return result;
 		}
@@ -88,25 +88,25 @@ namespace Alphalcazar::Game {
 		std::size_t placedPiecesCount = piecePlacements.count();
 		// If all pieces are on the board, immediatelly return an empty vector
 		if (placedPiecesCount != c_PieceTypes) {
-			result.reserve(c_PieceTypes - placedPiecesCount);
 			for (PieceType type = 1; type <= c_PieceTypes; type++) {
 				// Check if the piece type is not placed by the player on the board
 				if (!piecePlacements[type - 1]) {
-					result.emplace_back(player, type);
+					result.insert({ player, type });
 				}
 			}
 		}
 		return result;
 	}
 
-	std::vector<PlacementMove> Game::GetLegalMoves(PlayerId player) const {
-		std::vector<PlacementMove> result;
+	Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount> Game::GetLegalMoves(PlayerId player) const {
+		Utils::StaticVector<PlacementMove, c_PieceTypes* c_PerimeterTileCount> result;
 		auto legalCoordinates = mBoard.GetLegalPlacementCoordinates();
-		std::vector<Piece> pieces = GetPiecesInHand(player);
-		result.reserve(pieces.size() * legalCoordinates.size());
-		for (auto& coordinates : legalCoordinates) {
-			for (auto& piece : pieces) {
-				result.emplace_back(coordinates, piece.GetType());
+		auto pieces = GetPiecesInHand(player);
+		for (std::size_t i = 0; i < legalCoordinates.size(); ++i) {
+			const auto& coordinates = legalCoordinates[i];
+			for (std::size_t k = 0; k < pieces.size(); ++k) {
+				const auto& piece = pieces[k];
+				result.insert({ coordinates, piece.GetType() });
 			}
 		}
 		return result;

--- a/cpp/src/game/tests/Game.cpp
+++ b/cpp/src/game/tests/Game.cpp
@@ -13,7 +13,7 @@
 namespace Alphalcazar::Game {
 	class MockStrategy final : public Strategy {
 	public:
-		virtual PlacementMove Execute(PlayerId playerId, const std::vector<PlacementMove>&, const Game&) override {
+		virtual PlacementMove Execute(PlayerId playerId, const Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount>&, const Game&) override {
 			if (playerId == PlayerId::PLAYER_ONE) {
 				return { { 0, 2 }, 3 };
 			}

--- a/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
@@ -5,7 +5,6 @@
 #include "minmax/minmax_aliases.hpp"
 #include <util/StaticVector.hpp>
 
-#include <vector>
 #include <tuple>
 
 namespace Alphalcazar::Game {

--- a/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "game/aliases.hpp"
+#include "game/parameters.hpp"
 #include "minmax/minmax_aliases.hpp"
+#include <util/StaticVector.hpp>
 
 #include <vector>
 #include <tuple>
@@ -24,15 +26,15 @@ namespace Alphalcazar::Strategy::MinMax {
 
 	/*!
 	 * \brief Filters a list of legal movements, erasing those that are duplicated once board
-	 *        symmetries are taken into account.
+	 *        symmetries are taken into account and returns the filtered list.
 	 *
 	 * This means that if several moves would cause the resulting board states to be identical with some symmetry
 	 * (ex. x-axis symmetry), only one of those moves (the first one) is kept in the list.
 	 *
-	 * \param legalMoves The list of legal moves to filter. Will potentially be modified.
+	 * \param legalMoves The list of legal moves to filter.
 	 * \param board The board of the game for which the legal movements are valid.
 	 */
-	void FilterSymmetricMovements(std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board);
+	Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount> FilterSymmetricMovements(const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Board& board);
 
 	/*!
 	 * \brief Sorts a list of legal movements by the heuristic score we expect to obtain from playing
@@ -45,5 +47,5 @@ namespace Alphalcazar::Strategy::MinMax {
 	 * \param legalMoves The list of legal moves to sort. Will potentially be modified.
 	 * \param board The board of the game for which the legal movements are valid.
 	 */
-	void SortLegalMovements(Game::PlayerId playerId, std::vector<Game::PlacementMove>& legalMoves, const Game::Board& board);
+	void SortLegalMovements(Game::PlayerId playerId, Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Board& board);
 }

--- a/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
@@ -32,7 +32,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		MinMaxStrategy(const Depth depth, bool multithreaded = true);
 		~MinMaxStrategy();
 
-		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) override;
+		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game& game) override;
 
 		/// Returns the score calculated for the move returned by the last \ref Execute function call
 		Score GetLastExecutedMoveScore() const;

--- a/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
@@ -54,8 +54,9 @@ namespace Alphalcazar::Strategy::MinMax {
 
 	Score EvaluateBoard(Game::PlayerId playerId, const Game::Game& game) {
 		Score totalScore = 0;
-		auto pieces = game.GetBoard().GetPieces();
-		for (auto& [coordinates, piece] : pieces) {
+		auto [pieces, piecesCount] = game.GetBoard().GetPieces();
+		for (std::size_t i = 0; i < piecesCount; ++i) {
+			auto& [coordinates, piece] = pieces[i];
 			if (!coordinates.IsPerimeter()) {
 				auto direction = piece.GetMovementDirection();
 				float pieceScoreMultiplier = GetPieceScoreMultiplier(coordinates, direction);

--- a/cpp/src/strategies/minmax/tests/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/tests/LegalMovements.cpp
@@ -12,8 +12,6 @@
 
 #include "setuphelpers.hpp"
 
-#include <vector>
-
 namespace Alphalcazar::Strategy::MinMax {
 	TEST(LegalMovements, CenterVerticalRowSymmetries) {
 		Game::Game game {};

--- a/cpp/src/strategies/random/include/random/RandomStrategy.hpp
+++ b/cpp/src/strategies/random/include/random/RandomStrategy.hpp
@@ -19,7 +19,7 @@ namespace Alphalcazar::Strategy::Random {
 	class RandomStrategy final : public Game::Strategy {
 	public:
 		RandomStrategy();
-		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game& game) override;
+		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game& game) override;
 	private:
 		std::random_device mRandomDevice;
 		std::mt19937 mRandomEngine;

--- a/cpp/src/strategies/random/src/random/RandomStrategy.cpp
+++ b/cpp/src/strategies/random/src/random/RandomStrategy.cpp
@@ -9,8 +9,8 @@ namespace Alphalcazar::Strategy::Random {
 		, mRandomEngine { mRandomDevice() }
 	{}
 
-	Game::PlacementMove RandomStrategy::Execute(Game::PlayerId, const std::vector<Game::PlacementMove>& legalMoves, const Game::Game&) {
-		std::uniform_int_distribution<std::mt19937::result_type> distribution { 0, static_cast<std::mt19937::result_type>(legalMoves.size() - 1) };
+	Game::PlacementMove RandomStrategy::Execute(Game::PlayerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game&) {
+		std::uniform_int_distribution<std::mt19937::result_type> distribution { 0, static_cast<std::mt19937::result_type>(legalMoves.size() - 1)};
 		return legalMoves[distribution(mRandomEngine)];
 	}
 }

--- a/cpp/src/util/CMakeLists.txt
+++ b/cpp/src/util/CMakeLists.txt
@@ -15,3 +15,7 @@ set_target_properties(Alphalcazar.Utils PROPERTIES LINKER_LANGUAGE CXX)
 
 find_package(spdlog REQUIRED)
 target_link_libraries(Alphalcazar.Utils PUBLIC ${CONAN_LIBS_SPDLOG} spdlog::spdlog)
+
+if (BUILD_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/cpp/src/util/include/util/StaticVector.hpp
+++ b/cpp/src/util/include/util/StaticVector.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include <assert.h>
+
+namespace Alphalcazar::Utils {
+	/*!
+	 * \brief A list of variable size with an upper-bound capacity.
+	 *
+	 * \note The type T must be default-constructible and the capacity of the static vector must be greater than 0.
+	 * 
+	 * Usage example:
+	 * ```
+	 * StaticVector<int, 3> numbersVector;
+	 * numbersVector.Insert(2);
+	 * ...
+	 * auto [numbers, numbersCount] = numbersVector;
+	 * for(std::size_t i = 0; i < numbersCount; ++i) {
+	 *		int number = numbers[i];
+	 *		...
+	 * }
+	 * ```
+	 */
+	template<typename T, std::size_t Capacity>
+	struct StaticVector {
+		static_assert(Capacity > 0, "Capacity of StaticVector must be greater than 0");
+		static_assert(std::is_default_constructible_v<T>, "Value type of StaticVector must be default-constructible");
+		std::array<T, Capacity> mValues;
+		std::size_t mSize = 0;
+
+		typename std::array<T, Capacity>::iterator begin() {
+			return mValues.begin();
+		}
+
+		typename std::array<T, Capacity>::iterator end() {
+			return mValues.begin() + mSize;
+		}
+
+		typename std::array<T, Capacity>::const_iterator begin() const {
+			return mValues.begin();
+		}
+
+		typename std::array<T, Capacity>::const_iterator end() const {
+			return mValues.begin() + mSize;
+		}
+
+		void insert(const T& value) {
+			assert(mSize < Capacity);
+			mValues[mSize++] = value;
+		}
+
+		std::size_t size() const {
+			return mSize;
+		}
+
+		std::size_t empty() const {
+			return mSize == 0;
+		}
+
+		T& operator[](std::size_t index) {
+			assert(index < mSize);
+			return mValues[index];
+		}
+
+		const T& operator[](std::size_t index) const {
+			assert(index < mSize);
+			return mValues[index];
+		}
+	};
+
+	/*!
+	 * \brief Like \ref StaticVector but elements are added back-to-front instead of front-to-back.
+	 *
+	 * Usage example:
+	 * ```
+	 * StaticVector<int, 3> numbersVector;
+	 * numbersVector.Insert(2);
+	 * ...
+	 * auto [numbers, numbersCount] = numbersVector;
+	 * for(std::size_t i = numbers.size() - numbersCount; i < numbers.size(); ++i) {
+	 *		int number = numbers[i];
+	 *		...
+	 * }
+	 * ```
+	 */
+	template<typename T, std::size_t Capacity>
+	struct ReversedStaticVector {
+		static_assert(Capacity > 0, "Capacity of StaticVector must be greater than 0");
+		static_assert(std::is_default_constructible_v<T>, "Value type of ReversedStaticVector must be default-constructible");
+		std::array<T, Capacity> mValues;
+		std::size_t mSize = 0;
+
+		typename std::array<T, Capacity>::iterator begin() {
+			return mValues.end() - mSize;
+		}
+
+		typename std::array<T, Capacity>::iterator end() {
+			return mValues.end();
+		}
+
+		typename std::array<T, Capacity>::const_iterator begin() const {
+			return mValues.end() - mSize;
+		}
+
+		typename std::array<T, Capacity>::const_iterator end() const {
+			return mValues.end();
+		}
+
+		void insert(const T& value) {
+			assert(mSize < Capacity);
+			mValues[Capacity - mSize - 1] = value;
+			++mSize;
+		}
+
+		std::size_t size() const {
+			return mSize;
+		}
+
+		std::size_t empty() const {
+			return mSize == 0;
+		}
+
+		T& operator[](std::size_t index) {
+			assert(index < Capacity && index > (Capacity - mSize));
+			return mValues[index];
+		}
+
+		const T& operator[](std::size_t index) const {
+			return mValues[index];
+		}
+	};
+}

--- a/cpp/src/util/tests/CMakeLists.txt
+++ b/cpp/src/util/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+file(GLOB _sources
+    CONFIGURE_DEPENDS
+    "*.cpp"
+    "*.c"
+    "*.inl"
+    "*.h"
+    "*.hpp"
+)
+
+add_executable(Alphalcazar.Utils.Tests ${_sources})
+target_link_libraries(Alphalcazar.Utils.Tests Alphalcazar.Utils GTest::GTest)
+gtest_discover_tests(Alphalcazar.Utils.Tests)

--- a/cpp/src/util/tests/StaticVector.cpp
+++ b/cpp/src/util/tests/StaticVector.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <util/StaticVector.hpp>
+#include <string>
+#include <cstdint>
+
+namespace Alphalcazar::Utils {
+	TEST(StaticVector, InsertElements) {
+		StaticVector<int, 3> vector;
+		EXPECT_EQ(vector.size(), 0);
+		vector.insert(1);
+		EXPECT_EQ(vector.size(), 1);
+		vector.insert(2);
+		EXPECT_EQ(vector.size(), 2);
+	}
+
+	TEST(StaticVector, IteratorValues) {
+		StaticVector<std::string, 5> vector;
+		vector.insert("Hello!");
+		vector.insert("...");
+		vector.insert("Bye!");
+		EXPECT_EQ(*vector.begin(), "Hello!");
+		EXPECT_EQ(*(vector.end() - 1), "Bye!");
+
+		// An extra insert should affect the end, but not the beginning
+		vector.insert("Bye bye!");
+		EXPECT_EQ(*vector.begin(), "Hello!");
+		EXPECT_EQ(*(vector.end() - 1), "Bye bye!");
+	}
+
+	TEST(StaticVector, ValueAccess) {
+		StaticVector<float, 8> vector;
+		vector.insert(1.f);
+		vector.insert(2.f);
+		const StaticVector<float, 8> vectorCopy = vector;
+		EXPECT_EQ(vectorCopy[0], 1.f);
+		EXPECT_EQ(vectorCopy[1], 2.f);
+	}
+
+	TEST(ReversedStaticVector, InsertElements) {
+		ReversedStaticVector<std::uint32_t, 4> vector;
+		EXPECT_EQ(vector.size(), 0);
+		vector.insert(1);
+		EXPECT_EQ(vector.size(), 1);
+		vector.insert(2);
+		EXPECT_EQ(vector.size(), 2);
+	}
+
+	TEST(ReversedStaticVector, IteratorValues) {
+		struct TestStruct {
+			float x;
+			int y;
+		};
+
+		ReversedStaticVector<TestStruct, 10> vector;
+		vector.insert({1.f, 1});
+		vector.insert({2.f, 2});
+		vector.insert({3.f, 3});
+		EXPECT_EQ(vector.begin()->y, 3);
+		EXPECT_EQ((vector.end() - 1)->y, 1);
+
+		// An extra insert should affect the beginning, but not the end
+		vector.insert({ 4.f, 4 });
+		EXPECT_EQ(vector.begin()->y, 4);
+		EXPECT_EQ((vector.end() - 1)->y, 1);
+	}
+
+	TEST(ReversedStaticVector, ValueAccess) {
+		ReversedStaticVector<float, 8> vector;
+		vector.insert(1.f);
+		vector.insert(2.f);
+
+		const ReversedStaticVector<float, 8> vectorCopy = vector;
+		EXPECT_EQ(vectorCopy[7], 1.f);
+		EXPECT_EQ(vectorCopy[6], 2.f);
+	}
+}


### PR DESCRIPTION
Several methods of the `Board`/`Game` classes returned `std::vector` when there was no need for a dynamically sized list, as all these methods returned lists that were upper-bound in size.

Since this turned out to be a very common case across the game API, this PR introduces the `StaticVector` container wrapper (a pair of array/size) to cover this use case.

Before:
```
[2022-09-03 19:12:14.953] [info] First move at depth 1 took 1ms and calculated a score of 0
[2022-09-03 19:12:14.955] [info] Game at depth 1 took 1ms ended with result 3
[2022-09-03 19:12:14.981] [info] First move at depth 2 took 24ms and calculated a score of -34
[2022-09-03 19:12:15.083] [info] Game at depth 2 took 101ms ended with result 3
[2022-09-03 19:12:15.502] [info] First move at depth 3 took 417ms and calculated a score of 35
[2022-09-03 19:12:23.861] [info] Game at depth 3 took 8359ms ended with result 2
[2022-09-03 19:14:02.432] [info] First move at depth 4 took 98570ms and calculated a score of -64
```

After:
```
[2022-09-03 19:07:59.055] [info] First move at depth 1 took 1ms and calculated a score of 0
[2022-09-03 19:07:59.058] [info] Game at depth 1 took 1ms ended with result 3
[2022-09-03 19:07:59.085] [info] First move at depth 2 took 25ms and calculated a score of -34
[2022-09-03 19:07:59.189] [info] Game at depth 2 took 104ms ended with result 3
[2022-09-03 19:07:59.597] [info] First move at depth 3 took 407ms and calculated a score of 35
[2022-09-03 19:08:07.964] [info] Game at depth 3 took 8366ms ended with result 2
[2022-09-03 19:09:46.434] [info] First move at depth 4 took 98469ms and calculated a score of -64
```