### PR TITLE
Inline PlacementMove constructors

### DIFF
--- a/cpp/src/game/include/game/PlacementMove.hpp
+++ b/cpp/src/game/include/game/PlacementMove.hpp
@@ -14,9 +14,15 @@ namespace Alphalcazar::Game {
 	 * inwards.
 	 */
 	struct PlacementMove {
-		PlacementMove();
-		PlacementMove(const Coordinates& coordinates, PieceType pieceType);
-		~PlacementMove();
+		PlacementMove()
+			: Coordinates{ Coordinates::Invalid() }
+			, PieceType{ 0 }
+		{}
+
+		PlacementMove(const Coordinates& coordinates, PieceType pieceType)
+			: Coordinates{ coordinates }
+			, PieceType{ pieceType }
+		{}
 
 		Coordinates Coordinates;
 		PieceType PieceType;

--- a/cpp/src/game/src/game/PlacementMove.cpp
+++ b/cpp/src/game/src/game/PlacementMove.cpp
@@ -8,6 +8,8 @@ namespace Alphalcazar::Game {
 	}
 
 	bool PlacementMove::operator==(const PlacementMove& other) const {
-		return PieceType == other.PieceType && Coordinates == other.Coordinates;
+		bool pieceTypesMatch = PieceType == other.PieceType;
+		bool coordinatesMatch = Coordinates == other.Coordinates;
+		return pieceTypesMatch && coordinatesMatch;
 	}
 }

--- a/cpp/src/game/src/game/PlacementMove.cpp
+++ b/cpp/src/game/src/game/PlacementMove.cpp
@@ -1,20 +1,10 @@
 #include "game/PlacementMove.hpp"
 
 namespace Alphalcazar::Game {
-	PlacementMove::PlacementMove()
-		: Coordinates{ Coordinates::Invalid() }
-		, PieceType{ 0 }
-	{}
-
-	PlacementMove::PlacementMove(const Game::Coordinates& coordinates, Game::PieceType pieceType)
-		: Coordinates{ coordinates }
-		, PieceType{ pieceType }
-	{}
-
-	PlacementMove::~PlacementMove() {}
-
 	bool PlacementMove::Valid() const {
-		return Coordinates.Valid() && PieceType != 0;
+		bool coordinatesValid = Coordinates.Valid();
+		bool pieceTypeValid = PieceType != 0;
+		return coordinatesValid && pieceTypeValid;
 	}
 
 	bool PlacementMove::operator==(const PlacementMove& other) const {


### PR DESCRIPTION
Also removes the user-defined destructor and removes a branch in the `PlacementMove::Valid()` function. Does not significantly affect performance on its own, but becomes more relevant together with https://github.com/glecko/alphalcazar/pull/34.

Before:
```
[2022-09-04 11:20:41.717] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-09-04 11:20:41.720] [info] Game at depth 1 took 1ms ended with result 3
[2022-09-04 11:20:41.748] [info] First move at depth 2 took 27ms and calculated a score of -34
[2022-09-04 11:20:41.842] [info] Game at depth 2 took 93ms ended with result 3
[2022-09-04 11:20:42.243] [info] First move at depth 3 took 400ms and calculated a score of 35
[2022-09-04 11:20:50.458] [info] Game at depth 3 took 8213ms ended with result 2
[2022-09-04 11:22:23.987] [info] First move at depth 4 took 93528ms and calculated a score of -64
```

After:
```
[2022-09-04 11:18:07.201] [info] First move at depth 1 took 1ms and calculated a score of 0
[2022-09-04 11:18:07.205] [info] Game at depth 1 took 1ms ended with result 3
[2022-09-04 11:18:07.231] [info] First move at depth 2 took 25ms and calculated a score of -34
[2022-09-04 11:18:07.327] [info] Game at depth 2 took 95ms ended with result 3
[2022-09-04 11:18:07.734] [info] First move at depth 3 took 405ms and calculated a score of 35
[2022-09-04 11:18:15.998] [info] Game at depth 3 took 8264ms ended with result 2
[2022-09-04 11:19:52.160] [info] First move at depth 4 took 96161ms and calculated a score of -64
```