### PR TITLE
Replace Piece C-style bitfields with masks

### DIFF
--- a/cpp/src/game/include/game/Piece.hpp
+++ b/cpp/src/game/include/game/Piece.hpp
@@ -1,13 +1,17 @@
 #pragma once
 
 #include "aliases.hpp"
-#include "Coordinates.hpp"
+#include "parameters.hpp"
 #include <type_traits>
 
 namespace Alphalcazar::Game {
+	/// Mask used to obtain the owner from the piece info. See the docstring of \ref mPieceInfo
 	constexpr std::uint8_t c_PieceOwnerMask = 0b00000011;
+	/// Mask used to obtain the direction from the piece info. See the docstring of \ref mPieceInfo
 	constexpr std::uint8_t c_PieceDirectionMask = 0b00011100;
+	/// Mask used to obtain the piece type from the piece info. See the docstring of \ref mPieceInfo
 	constexpr std::uint8_t c_PieceTypeMask = 0b11100000;
+	/// Mask used to obtain the piece owner & type data from the piece info. See the docstring of \ref mPieceInfo
 	constexpr std::uint8_t c_PieceTypeAndOwnerMask = c_PieceOwnerMask ^ c_PieceTypeMask;
 
 	/*!

--- a/cpp/src/game/include/game/Piece.hpp
+++ b/cpp/src/game/include/game/Piece.hpp
@@ -2,8 +2,14 @@
 
 #include "aliases.hpp"
 #include "Coordinates.hpp"
+#include <type_traits>
 
 namespace Alphalcazar::Game {
+	constexpr std::uint8_t c_PieceOwnerMask = 0b00000011;
+	constexpr std::uint8_t c_PieceDirectionMask = 0b00011100;
+	constexpr std::uint8_t c_PieceTypeMask = 0b11100000;
+	constexpr std::uint8_t c_PieceTypeAndOwnerMask = c_PieceOwnerMask ^ c_PieceTypeMask;
+
 	/*!
 	 * \brief Represents a piece that belongs to a player.
 	 *
@@ -13,88 +19,85 @@ namespace Alphalcazar::Game {
 	class Piece {
 	public:
 		/// Default constructor for \ref Piece, constructs an invalid piece
-		Piece() noexcept
-			: mType{ c_InvalidPieceType }
-			, mDirection{ Direction::NONE }
-			, mOwner{ PlayerId::NONE }
-		{}
+		Piece() noexcept {}
 
-		Piece(PlayerId owner, PieceType type) noexcept
-			: mType{ type }
-			, mDirection{ Direction::NONE }
-			, mOwner{ owner }
-		{}
+		Piece(PlayerId owner, PieceType type) noexcept {
+			// Combine the bit representations of the owner and type (shifted 5 bits to the left to be properly aligned).
+			// The resulting \ref mPieceInfo will have the bits representing the direction (4-6 from the left) set to 0.
+			auto alignedOwnerData = static_cast<std::underlying_type<PlayerId>::type>(owner);
+			PieceType alignedTypeData = (type << 5);
+			mPieceInfo = alignedTypeData ^ alignedOwnerData;
+		}
 
 		/// Returns the type (that determines the movement order) of the piece
 		PieceType GetType() const {
-			return mType;
+			// No need to apply the \ref c_PieceTypeMask here, since the type is represented
+			// at the 3 left-most bits of \ref mPieceInfo, by shifting 5 bits to the right
+			// we are already zeroing all the other bits. It's very likely the compiler would optimize
+			// out the flag operation anyways, but it's best not to rely on that.
+			return mPieceInfo >> 5;
 		}
 
 		/// Retrusn the owner of the piece
 		PlayerId GetOwner() const {
-			return mOwner;
+			return static_cast<PlayerId>(mPieceInfo & c_PieceOwnerMask);
 		}
 
 		/// Returns the direction at which the piece is currently facing
 		Direction GetMovementDirection() const {
-			return mDirection;
+			std::uint8_t unalignedDirectionData = mPieceInfo & c_PieceDirectionMask;
+			std::uint8_t alignedDirectionData = unalignedDirectionData >> 2;
+			return static_cast<Direction>(alignedDirectionData);
 		}
 
 		/// Returns whether the piece can be pushed by the movement of other pieces
 		bool IsPushable() const {
-			return mType == c_PushablePieceType;
+			return GetType() == c_PushablePieceType;
 		}
 
 		/// Returns whether the piece can push other pieces when moving
 		bool IsPusher() const {
-			return mType == c_PusherPieceType;
+			return GetType() == c_PusherPieceType;
 		}
 
 		/// Returns if the data structure represents a valid piece
 		bool IsValid() const {
 			// Since at all calls of this function, all relevant values are loaded in the L1 cache,
 			// we parallelise the comparisons to avoid branching (causing a potential instruction-level cache miss)
-			bool typeIsValid = mType != c_InvalidPieceType;
-			bool ownerIsValid = mOwner != PlayerId::NONE;
+			bool typeIsValid = GetType() != c_InvalidPieceType;
+			bool ownerIsValid = (mPieceInfo & c_PieceOwnerMask) != 0;
 			return typeIsValid && ownerIsValid;
 		}
 
 		/// Sets the direction at which the piece is facing
 		void SetMovementDirection(Direction direction) {
-			mDirection = direction;
+			std::uint8_t alignedDirectionData = static_cast<std::uint8_t>(direction) << 2;
+			mPieceInfo ^= alignedDirectionData;
 		}
 
 		bool operator==(const Piece& other) const {
-			// Since at all calls of this function, all relevant values are loaded in the L1 cache,
-			// we parallelise the comparisons to avoid branching (causing a potential instruction-level cache miss)
-			bool typeMatches = other.mType == mType;
-			bool ownerMatches = other.mOwner == mOwner;
-			return typeMatches && ownerMatches;
+			std::uint8_t pieceTypeAndOwnerData = mPieceInfo & c_PieceTypeAndOwnerMask;
+			std::uint8_t otherPieceTypeAndOwnerData = other.mPieceInfo & c_PieceTypeAndOwnerMask;
+			return pieceTypeAndOwnerData == otherPieceTypeAndOwnerData;
 		}
 	private:
 		/*!
-		 * \brief The type, or movement order, of the piece.
+		 * \brief A 8-bit field containing the information about the piece.
 		 *
-		 * The type of a piece indicates in which order (relative to other pieces) the piece will execute its movement
-		 * in the movement phase at the end of each turn.
+		 * The 3 left-most bits are used to represent the type, or movement order, of the piece.
+		 * It indicates in which order (relative to other pieces) the piece will execute its movement in the movement phase at the end of each turn.
+		 * Since currently there are 6 possible values for this state (5 pieces and invalid), we use 3 bits (8 possible states) for it.
 		 *
-		 * \note Since currently there are 6 possible values for this state (5 pieces and invalid), we assign 3 bits (8 possible states)
-		 *       to this member.
+		 * The next 2 bits (4-6 from the left) are used to represent the movement direction of the piece while it is in play on the board.
+		 * In theory there are 9 possible states for this field (4 cardinal directions, 4 intercardinal directions and the invalid state).
+		 * However, the game rules currently only allow pieces to have one of the 4 cardinal directions. Therefore we can (until this changes) use
+		 * 3 bits (8 possible states) for it.
+		 *
+		 * The last 2 bits (7-8 from the left) are used to represent the ID of the player that owns this piece.
+		 * Since currently there are 3 possible values for this state (2 players and none), we use 2 bits (4 possible states) for it.
+		 *
+		 * Storing the data this way makes the whole \ref Piece struct as a whole take up 1 byte, which is very convenient.
 		 */
-		PieceType mType : 3;
-		/*!
-		 * \brief The movement direction of the piece while it is in play on the board
-		 *
-		 * \note In theory there are 9 possible states for this field (4 cardinal directions, 4 intercardinal directions and the invalid state).
-		 *       However, the game rules currently only allow pieces to have one of the 4 cardinal directions. Therefore we can (until this changes) assign
-		 *       3 bits (8 possible states) to this field. This makes the whole \ref Piece struct as a whole take up 1 byte, which is very convenient.
-		 */
-		Direction mDirection : 3;
-		/*!
-		 * \brief The ID of the player that owns this piece.
-		 *
-		 * \note Since currently there are 3 possible values for this state (2 players and none), we assign 2 bits (4 possible states) to this member.
-		 */
-		PlayerId mOwner : 2;
+		std::uint8_t mPieceInfo = 0;
 	};
 }


### PR DESCRIPTION
C++ bitfields are very platform/implementation dependant, so we remove them and replace them by explicit bitshifts / bit-wise operations. Does not seem to have a noticeable performance impact on Windows with MSVS.

Before:
```
[2022-09-12 17:39:21.687] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-09-12 17:39:21.688] [info] Game at depth 1 took 0ms ended with result 3
[2022-09-12 17:39:21.696] [info] First move at depth 2 took 7ms and calculated a score of -34
[2022-09-12 17:39:21.730] [info] Game at depth 2 took 33ms ended with result 3
[2022-09-12 17:39:21.923] [info] First move at depth 3 took 191ms and calculated a score of 35
[2022-09-12 17:39:25.458] [info] Game at depth 3 took 3534ms ended with result 2
[2022-09-12 17:39:49.257] [info] First move at depth 4 took 23798ms and calculated a score of -64
```

After:
```
[2022-09-12 17:36:42.856] [info] First move at depth 1 took 0ms and calculated a score of 0
[2022-09-12 17:36:42.858] [info] Game at depth 1 took 1ms ended with result 3
[2022-09-12 17:36:42.866] [info] First move at depth 2 took 6ms and calculated a score of -34
[2022-09-12 17:36:42.901] [info] Game at depth 2 took 33ms ended with result 3
[2022-09-12 17:36:43.094] [info] First move at depth 3 took 191ms and calculated a score of 35
[2022-09-12 17:36:46.608] [info] Game at depth 3 took 3514ms ended with result 2
[2022-09-12 17:37:09.627] [info] First move at depth 4 took 23018ms and calculated a score of -64
```