### PR TITLE
Improve const-correctness & remove redundant includes

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -130,8 +130,8 @@ namespace Alphalcazar::Game {
 		Utils::ReversedStaticVector<Board::MovementDescription, c_PlayAreaSize> GetChainedPushMovements(const Coordinates& sourceCoordinates, Direction direction);
 
 		/// Executes a specified function for every tile of this board
-		void LoopOverTiles(std::function<void(const Coordinates& coordinates, const Tile& tile)> action) const;
-		void LoopOverTiles(std::function<void(const Coordinates& coordinates, Tile& tile)> action);
+		void LoopOverTiles(const std::function<void(const Coordinates& coordinates, const Tile& tile)>& action) const;
+		void LoopOverTiles(const std::function<void(const Coordinates& coordinates, Tile& tile)>& action);
 
 		/// Get the coordinates at which a given piece is placed on the board. Returns invalid coordinates if the piece does not exist on the board.
 		Coordinates& GetPlacedPieceCoordinates(const Piece& piece);
@@ -149,7 +149,7 @@ namespace Alphalcazar::Game {
 		 * \param excludePerimeter Whether to skip executing the action for pieces placed on the perimeter of the board.
 		 * \param action The action to execute for every piece.
 		 */
-		void FetchPiecesFromIndexRange(std::size_t min, std::size_t max, bool excludePerimeter, std::function<void(const Coordinates& coordinates, const Piece& piece)> action) const;
+		void FetchPiecesFromIndexRange(std::size_t min, std::size_t max, bool excludePerimeter, const std::function<void(const Coordinates& coordinates, const Piece& piece)>& action) const;
 
 		/// 2D array containing all tiles of the board (both perimeter and board tiles) indexed by their coordinates
 		std::array<std::array<Tile, c_PlayAreaSize>, c_PlayAreaSize> mTiles;

--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -7,7 +7,6 @@
 #include "util/StaticVector.hpp"
 
 #include <array>
-#include <memory>
 #include <optional>
 #include <functional>
 #include <bitset>

--- a/cpp/src/game/include/game/Coordinates.hpp
+++ b/cpp/src/game/include/game/Coordinates.hpp
@@ -22,8 +22,8 @@ namespace Alphalcazar::Game {
 		bool operator==(const Coordinates& coord) const {
 			// Since at all calls of this function, all relevant values are loaded in the L1 cache,
 			// we parallelise the comparisons to avoid branching (causing a potential instruction-level cache miss)
-			bool xIsEqual = x == coord.x;
-			bool yIsEqual = y == coord.y;
+			const bool xIsEqual = x == coord.x;
+			const bool yIsEqual = y == coord.y;
 			return xIsEqual && yIsEqual;
 		}
 
@@ -45,8 +45,8 @@ namespace Alphalcazar::Game {
 		bool IsCenter() const {
 			// Since at all calls of this function, all relevant values are loaded in the L1 cache,
 			// we parallelise the comparisons to avoid branching (causing a potential instruction-level cache miss)
-			bool xIsCenter = x == c_CenterCoordinate;
-			bool yIsCenter = y == c_CenterCoordinate;
+			const bool xIsCenter = x == c_CenterCoordinate;
+			const bool yIsCenter = y == c_CenterCoordinate;
 			return xIsCenter && yIsCenter;
 		}
 
@@ -59,8 +59,8 @@ namespace Alphalcazar::Game {
 		bool IsCorner() const {
 			// Since at all calls of this function, all relevant values are loaded in the L1 cache,
 			// we parallelise the comparisons to avoid branching (causing a potential instruction-level cache miss)
-			bool xIsPerimeter = x == 0 || x == c_PlayAreaSize - 1;
-			bool yIsPerimeter = y == 0 || y == c_PlayAreaSize - 1;
+			const bool xIsPerimeter = x == 0 || x == c_PlayAreaSize - 1;
+			const bool yIsPerimeter = y == 0 || y == c_PlayAreaSize - 1;
 			return xIsPerimeter && yIsPerimeter;
 		}
 
@@ -73,8 +73,8 @@ namespace Alphalcazar::Game {
 		bool Valid() const {
 			// Since at all calls of this function, all relevant values are loaded in the L1 cache,
 			// we parallelise the comparisons to avoid branching (causing a potential instruction-level cache miss)
-			bool xIsInvalid = x != c_InvalidCoordinate;
-			bool yIsInvalid = y != c_InvalidCoordinate;
+			const bool xIsInvalid = x != c_InvalidCoordinate;
+			const bool yIsInvalid = y != c_InvalidCoordinate;
 			return xIsInvalid && yIsInvalid;
 		}
 
@@ -133,7 +133,7 @@ namespace std {
 
 // We define the specializations of parse & format to make \ref Coordinates formattable. Based on: https://fmt.dev/latest/api.html#format-api
 template <> struct fmt::formatter<Alphalcazar::Game::Coordinates> {
-	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+	constexpr auto parse(const format_parse_context& ctx) -> decltype(ctx.begin()) {
 		return ctx.begin();
 	}
 

--- a/cpp/src/game/include/game/Game.hpp
+++ b/cpp/src/game/include/game/Game.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 #include "aliases.hpp"
 #include "Board.hpp"
 #include <util/StaticVector.hpp>
@@ -90,7 +89,7 @@ namespace Alphalcazar::Game {
 		 *
 		 * \param executedMoves The amount of moves executed on the last turn.
 		 */
-		GameResult EvaluateGameResult(BoardMovesCount executedMoves);
+		GameResult EvaluateGameResult(BoardMovesCount executedMoves) const;
 
 		/// The board on which the game is being played
 		Board mBoard;

--- a/cpp/src/game/include/game/PlacementMove.hpp
+++ b/cpp/src/game/include/game/PlacementMove.hpp
@@ -36,7 +36,7 @@ namespace Alphalcazar::Game {
 
 // We define the specializations of parse & format to make \ref PlacementMove formattable. Based on: https://fmt.dev/latest/api.html#format-api
 template <> struct fmt::formatter<Alphalcazar::Game::PlacementMove> {
-	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+	constexpr auto parse(const format_parse_context& ctx) -> decltype(ctx.begin()) {
 		return ctx.begin();
 	}
 

--- a/cpp/src/game/include/game/Tile.hpp
+++ b/cpp/src/game/include/game/Tile.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include "aliases.hpp"
 #include "Piece.hpp"
-#include <memory>
-#include <optional>
 
 namespace Alphalcazar::Game {
 	/*!

--- a/cpp/src/game/include/game/parameters.hpp
+++ b/cpp/src/game/include/game/parameters.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include "aliases.hpp"
 #include <cstddef>
 

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -201,7 +201,7 @@ namespace Alphalcazar::Game {
 	}
 
 	const Tile* Board::GetTile(Coordinate x, Coordinate y) const {
-		Coordinates coord{ x, y };
+		const Coordinates coord{ x, y };
 		return GetTile(coord);
 	}
 

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -82,7 +82,7 @@ namespace Alphalcazar::Game {
 			const Piece& originPiece = originTile->GetPiece();
 
 			const Direction direction = originPiece.GetMovementDirection();
-			Coordinates targetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 1);
+			const Coordinates targetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 1);
 			if (Tile* targetTile = GetTile(targetCoordinates)) {
 				const Piece& targetTilePiece = targetTile->GetPiece();
 				if (!targetTilePiece.IsValid()) {
@@ -114,12 +114,12 @@ namespace Alphalcazar::Game {
 						movedPieces += 2;
 					} else if (originCoordinates.IsPerimeter()) {
 						// if a piece was unable to perform any movement on its turn while sitting on
-						// a perimeter tile, it is immediatelly removed from play
+						// a perimeter tile, it is immediately removed from play
 						RemovePiece(*originTile);
 					}
 				} else if (originCoordinates.IsPerimeter()) {
 					// if a piece was unable to perform any movement on its turn while sitting on
-					// a perimeter tile, it is immediatelly removed from play
+					// a perimeter tile, it is immediately removed from play
 					RemovePiece(*originTile);
 				}
 			}
@@ -140,13 +140,13 @@ namespace Alphalcazar::Game {
 
 	Utils::ReversedStaticVector<Board::MovementDescription, c_PlayAreaSize> Board::GetChainedPushMovements(const Coordinates& sourceCoordinates, Direction direction) {
 		// The max amount of chained pushed movements that can exist is \ref c_PlayAreaSize
-		Utils::ReversedStaticVector<Board::MovementDescription, c_PlayAreaSize> result;
+		Utils::ReversedStaticVector<MovementDescription, c_PlayAreaSize> result;
 		Coordinates nextCoordinate = sourceCoordinates;
 		Tile* nextTile = GetTile(nextCoordinate);
 		while (nextTile && nextTile->HasPiece()) {
 			// Get the coordinates and tile this piece will be pushed to
-			auto pushToCoordinate = nextCoordinate.GetCoordinateInDirection(direction, 1);
-			auto pushToTile = GetTile(pushToCoordinate);
+			const auto pushToCoordinate = nextCoordinate.GetCoordinateInDirection(direction, 1);
+			Tile* pushToTile = GetTile(pushToCoordinate);
 
 			// Insert movements back-to-front into the array, as the pushing movements will need to happen in order
 			// from the last piece on the chain to the first (pushing) piece
@@ -163,7 +163,7 @@ namespace Alphalcazar::Game {
 	void Board::MovePiece(Tile& source, Tile& target, const Coordinates& targetCoordinates) {
 		if (source.HasPiece()) {
 			const auto& piece = source.GetPiece();
-			// A piece that moves or is moved to a perimeter tile gets removed from play immediatelly
+			// A piece that moves or is moved to a perimeter tile gets removed from play immediately
 			if (!targetCoordinates.IsPerimeter()) {
 				SetPlacedPieceCoordinates(piece, targetCoordinates);
 				target.PlacePiece(piece);
@@ -249,7 +249,7 @@ namespace Alphalcazar::Game {
 	bool Board::IsFull() const {
 		bool result = true;
 		LoopOverTiles([&result](const Coordinates& coordinates, const Tile& tile) {
-			// If we find a single non-perimetter file that has no piece on it, we return false
+			// If we find a single non-perimeter file that has no piece on it, we return false
 			if (!coordinates.IsPerimeter() && !tile.HasPiece()) {
 				result = false;
 				return;
@@ -291,7 +291,7 @@ namespace Alphalcazar::Game {
 		std::optional<PlayerId> candidateRowCompleter = std::nullopt;
 
 		for (Coordinate distance = 0; distance < length; ++distance) {
-			Coordinates nextCoordinate = startCoordinate.GetCoordinateInDirection(direction, distance);
+			const Coordinates nextCoordinate = startCoordinate.GetCoordinateInDirection(direction, distance);
 			if (const auto& piece = mTiles[nextCoordinate.x][nextCoordinate.y].GetPiece(); piece.IsValid()) {
 				if (candidateRowCompleter == std::nullopt) {
 					// We appoint the owner of the first piece we find as our candidate
@@ -310,16 +310,16 @@ namespace Alphalcazar::Game {
 	}
 
 	Coordinates& Board::GetPlacedPieceCoordinates(const Piece& piece) {
-		std::size_t index = GetPlacedPieceTypeIndex(piece);
+		const std::size_t index = GetPlacedPieceTypeIndex(piece);
 		return mPlacedPieceCoordinates[index];
 	}
 
 	void Board::SetPlacedPieceCoordinates(const Piece& piece, const Coordinates& coordinates) {
-		std::size_t index = GetPlacedPieceTypeIndex(piece);
+		const std::size_t index = GetPlacedPieceTypeIndex(piece);
 		mPlacedPieceCoordinates[index] = coordinates;
 	}
 
-	void Board::FetchPiecesFromIndexRange(std::size_t min, std::size_t max, bool excludePerimeter, std::function<void(const Coordinates& coordinates, const Piece& piece)> action) const {
+	void Board::FetchPiecesFromIndexRange(std::size_t min, std::size_t max, bool excludePerimeter, const std::function<void(const Coordinates& coordinates, const Piece& piece)>& action) const {
 		for (std::size_t i = min; i <= max; i++) {
 			auto& coordinates = mPlacedPieceCoordinates[i];
 			if (coordinates.Valid()) {
@@ -363,9 +363,9 @@ namespace Alphalcazar::Game {
 			return 0;
 		}
 		std::size_t pieceCount = 0;
-		auto [min, max] = GetPlacePieceIndexRange(player);
+		const auto [min, max] = GetPlacePieceIndexRange(player);
 		for (std::size_t i = min; i <= max; i++) {
-			auto coordinates = mPlacedPieceCoordinates[i];
+			const auto& coordinates = mPlacedPieceCoordinates[i];
 			if (coordinates.Valid()) {
 				if (!excludePerimeter || !coordinates.IsPerimeter()) {
 					pieceCount++;
@@ -388,7 +388,7 @@ namespace Alphalcazar::Game {
 		return result;
 	}
 
-	void Board::LoopOverTiles(std::function<void(const Coordinates& coordinates, const Tile& tile)> action) const {
+	void Board::LoopOverTiles(const std::function<void(const Coordinates& coordinates, const Tile& tile)>& action) const {
 		for (Coordinate x = 0; x <= c_PlayAreaSize - 1; x++) {
 			for (Coordinate y = 0; y <= c_PlayAreaSize - 1; y++) {
 				Coordinates coordinates { x, y };
@@ -401,7 +401,7 @@ namespace Alphalcazar::Game {
 		}
 	}
 
-	void Board::LoopOverTiles(std::function<void(const Coordinates& coordinates, Tile& tile)> action) {
+	void Board::LoopOverTiles(const std::function<void(const Coordinates& coordinates, Tile& tile)>& action) {
 		for (Coordinate x = 0; x <= c_PlayAreaSize - 1; x++) {
 			for (Coordinate y = 0; y <= c_PlayAreaSize - 1; y++) {
 				Coordinates coordinates { x, y };

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -5,16 +5,14 @@
 #include "safety_checks.hpp"
 #include <util/Log.hpp>
 
-#include <algorithm>
-
 namespace {
 	/// Returns the index of the \ref mPlacedPieceCoordinates array of a given piece
 	std::size_t GetPlacedPieceTypeIndex(const Alphalcazar::Game::Piece& piece) {
-		std::size_t pieceTypeIndex = static_cast<std::size_t>(piece.GetType());
+		const std::size_t pieceTypeIndex = static_cast<std::size_t>(piece.GetType());
 		// The first 5 positions of the array are held by the (1-5) pieces of player one,
 		// the next 5 position by the (1-5) pieces of player 2. To get the index, we get the piece index
 		// and shift it forward by 5 for player 2 and by 0 for player 1.
-		std::size_t pieceOwnerOffset = static_cast<std::size_t>(piece.GetOwner()) - 1;
+		const std::size_t pieceOwnerOffset = static_cast<std::size_t>(piece.GetOwner()) - 1;
 		return pieceTypeIndex + (pieceOwnerOffset * Alphalcazar::Game::c_PieceTypes) - 1;
 	}
 
@@ -39,9 +37,9 @@ namespace {
 }
 
 namespace Alphalcazar::Game {
-	Board::Board() {}
+	Board::Board() = default;
 
-	Board::~Board() {}
+	Board::~Board() = default;
 
 	void Board::PlacePiece(const Coordinates& coordinates, const Piece& piece) {
 		Tile* tile = GetTile(coordinates);
@@ -50,7 +48,7 @@ namespace Alphalcazar::Game {
 				Utils::LogError("Attempted to place a piece on a non-existing perimeter tile (at {})", coordinates);
 			}
 		}
-		auto direction = coordinates.GetLegalPlacementDirection();
+		const Direction direction = coordinates.GetLegalPlacementDirection();
 		if constexpr (c_BoardPiecePlacementIntegrityChecks) {
 			if (direction == Direction::NONE) {
 				Utils::LogError("Legal placement direction of piece placement at {} was invalid.", coordinates);
@@ -83,7 +81,7 @@ namespace Alphalcazar::Game {
 			Tile* originTile = GetTile(originCoordinates);
 			const Piece& originPiece = originTile->GetPiece();
 
-			auto direction = originPiece.GetMovementDirection();
+			const Direction direction = originPiece.GetMovementDirection();
 			Coordinates targetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 1);
 			if (Tile* targetTile = GetTile(targetCoordinates)) {
 				const Piece& targetTilePiece = targetTile->GetPiece();
@@ -105,8 +103,8 @@ namespace Alphalcazar::Game {
 						movedPieces++;
 					}
 				} else if (targetTilePiece.IsPushable() && !originPiece.IsPushable()) {
-					auto pushTargetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 2);
-					auto* pushTargetTile = GetTile(pushTargetCoordinates);
+					const Coordinates pushTargetCoordinates = originCoordinates.GetCoordinateInDirection(direction, 2);
+					Tile* pushTargetTile = GetTile(pushTargetCoordinates);
 					// A non-pushing piece cannot push a pushable piece if there is a piece on the tile
 					// it would be pushed to. It doesn't matter if the piece behind it is also pushable
 					if (!pushTargetTile->HasPiece()) {
@@ -132,9 +130,9 @@ namespace Alphalcazar::Game {
 	BoardMovesCount Board::ExecuteMoves(PlayerId startingPlayerId) {
 		BoardMovesCount movedPieces = 0;
 		for (PieceType pieceTypeToMove = 1; pieceTypeToMove <= c_PieceTypes; pieceTypeToMove++) {
-			Piece startingPlayerPiece { startingPlayerId, pieceTypeToMove };
+			const Piece startingPlayerPiece { startingPlayerId, pieceTypeToMove };
 			movedPieces += ExecutePieceMove(startingPlayerPiece);
-			Piece secondPlayerPiece { startingPlayerId == PlayerId::PLAYER_ONE ? PlayerId::PLAYER_TWO : PlayerId::PLAYER_ONE, pieceTypeToMove };
+			const Piece secondPlayerPiece { startingPlayerId == PlayerId::PLAYER_ONE ? PlayerId::PLAYER_TWO : PlayerId::PLAYER_ONE, pieceTypeToMove };
 			movedPieces += ExecutePieceMove(secondPlayerPiece);
 		}
 		return movedPieces;
@@ -191,7 +189,7 @@ namespace Alphalcazar::Game {
 	}
 
 	Tile* Board::GetTile(Coordinate x, Coordinate y) {
-		Coordinates coord { x, y };
+		const Coordinates coord { x, y };
 		return GetTile(coord);
 	}
 
@@ -208,8 +206,7 @@ namespace Alphalcazar::Game {
 	}
 
 	Tile* Board::GetPieceTile(const Piece& piece) {
-		Coordinates& coordinates = GetPlacedPieceCoordinates(piece);
-		if (coordinates.Valid()) {
+		if (const Coordinates& coordinates = GetPlacedPieceCoordinates(piece); coordinates.Valid()) {
 			return GetTile(coordinates);
 		}
 		return nullptr;

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -58,10 +58,10 @@ namespace Alphalcazar::Game {
 			}
 		}
 
-		std::size_t directionOffset = static_cast<std::size_t>(direction);
+		const std::size_t directionOffset = static_cast<std::size_t>(direction);
 		const auto& offset = c_DirectionOffsets[directionOffset];
-		Coordinate xOffset = offset.first * distance;
-		Coordinate yOffset = offset.second * distance;
+		const Coordinate xOffset = offset.first * distance;
+		const Coordinate yOffset = offset.second * distance;
 		return Coordinates{ x + xOffset, y + yOffset };
 	}
 

--- a/cpp/src/game/src/game/Coordinates.cpp
+++ b/cpp/src/game/src/game/Coordinates.cpp
@@ -29,7 +29,7 @@ namespace Alphalcazar::Game {
 	}};
 
 	Direction Coordinates::GetLegalPlacementDirection() const {
-		if (c_CoordinatesIntegrityChecks) {
+		if constexpr (c_CoordinatesIntegrityChecks) {
 			if (!IsPerimeter()) {
 				// Pieces cannot be placed on non-perimeter tiles.
 				return Direction::NONE;
@@ -37,13 +37,14 @@ namespace Alphalcazar::Game {
 		}
 		if (x == 0) {
 			return Direction::EAST;
-		} else if (x == c_PlayAreaSize - 1) {
-			return Direction::WEST;
-		} else if (y == 0) {
-			return Direction::NORTH;
-		} else {
-			return Direction::SOUTH;
 		}
+		if (x == c_PlayAreaSize - 1) {
+			return Direction::WEST;
+		}
+		if (y == 0) {
+			return Direction::NORTH;
+		}
+		return Direction::SOUTH;
 	}
 
 	Coordinates Coordinates::GetCoordinateInDirection(Direction direction, Coordinate distance) const {
@@ -58,7 +59,7 @@ namespace Alphalcazar::Game {
 			}
 		}
 
-		const std::size_t directionOffset = static_cast<std::size_t>(direction);
+		const auto directionOffset = static_cast<std::size_t>(direction);
 		const auto& offset = c_DirectionOffsets[directionOffset];
 		const Coordinate xOffset = offset.first * distance;
 		const Coordinate yOffset = offset.second * distance;

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -83,7 +83,7 @@ namespace Alphalcazar::Game {
 
 		const auto piecePlacements = mBoard.GetPiecePlacements(player);
 		const std::size_t placedPiecesCount = piecePlacements.count();
-		// If all pieces are on the board, immediatelly return an empty vector
+		// If all pieces are on the board, immediately return an empty vector
 		if (placedPiecesCount != c_PieceTypes) {
 			for (PieceType type = 1; type <= c_PieceTypes; type++) {
 				// Check if the piece type is not placed by the player on the board

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -1,17 +1,14 @@
 #include "game/Game.hpp"
 
-#include "game/Tile.hpp"
 #include "game/PlacementMove.hpp"
 #include "game/parameters.hpp"
 #include "game/Strategy.hpp"
 #include "game/Piece.hpp"
 
-#include <util/Log.hpp>
-
 namespace Alphalcazar::Game {
-	Game::Game() {}
+	Game::Game() = default;
 
-	Game::~Game() {};
+	Game::~Game() = default;
 
 	GameResult Game::Play(Strategy& firstPlayerStrategy, Strategy& secondPlayerStrategy) {
 		GameResult result = GameResult::NONE;
@@ -27,7 +24,7 @@ namespace Alphalcazar::Game {
 	}
 
 	GameResult Game::PlayNextPlacementMove(const PlacementMove& move) {
-		PlayerId activePlayer = GetActivePlayer();
+		const PlayerId activePlayer = GetActivePlayer();
 		auto result = GameResult::NONE;
 		ExecutePlacementMove(activePlayer, move);
 		if (mState.FirstMoveExecuted) {
@@ -39,7 +36,7 @@ namespace Alphalcazar::Game {
 	}
 
 	GameResult Game::EvaluateTurnEndPhase() {
-		auto executedMoves = mBoard.ExecuteMoves(mState.PlayerWithInitiative);
+		const auto executedMoves = mBoard.ExecuteMoves(mState.PlayerWithInitiative);
 		mState.Turn += 1;
 		mState.FirstMoveExecuted = false;
 		SwapPlayerWithInitiative();
@@ -65,16 +62,16 @@ namespace Alphalcazar::Game {
 	}
 
 	void Game::ExecutePlayerMove(PlayerId playerId, Strategy& strategy) {
-		auto legalMoves = GetLegalMoves(playerId);
+		const auto legalMoves = GetLegalMoves(playerId);
 		// If a player has no available legal moves, their turn is skipped
 		if (legalMoves.size() > 0) {
-			auto placementMove = strategy.Execute(playerId, legalMoves, *this);
+			const auto placementMove = strategy.Execute(playerId, legalMoves, *this);
 			ExecutePlacementMove(playerId, placementMove);
 		}
 	}
 
 	void Game::ExecutePlacementMove(PlayerId playerId, const PlacementMove& move) {
-		Piece piece = { playerId, move.PieceType };
+		const Piece piece = { playerId, move.PieceType };
 		mBoard.PlacePiece(move.Coordinates, piece);
 	}
 
@@ -84,8 +81,8 @@ namespace Alphalcazar::Game {
 			return result;
 		}
 
-		auto piecePlacements = mBoard.GetPiecePlacements(player);
-		std::size_t placedPiecesCount = piecePlacements.count();
+		const auto piecePlacements = mBoard.GetPiecePlacements(player);
+		const std::size_t placedPiecesCount = piecePlacements.count();
 		// If all pieces are on the board, immediatelly return an empty vector
 		if (placedPiecesCount != c_PieceTypes) {
 			for (PieceType type = 1; type <= c_PieceTypes; type++) {
@@ -102,17 +99,15 @@ namespace Alphalcazar::Game {
 		Utils::StaticVector<PlacementMove, c_PieceTypes* c_PerimeterTileCount> result;
 		auto legalCoordinates = mBoard.GetLegalPlacementCoordinates();
 		auto pieces = GetPiecesInHand(player);
-		for (std::size_t i = 0; i < legalCoordinates.size(); ++i) {
-			const auto& coordinates = legalCoordinates[i];
-			for (std::size_t k = 0; k < pieces.size(); ++k) {
-				const auto& piece = pieces[k];
+		for (const Coordinates& coordinates : legalCoordinates) {
+			for (const Piece& piece : pieces) {
 				result.insert({ coordinates, piece.GetType() });
 			}
 		}
 		return result;
 	}
 
-	GameResult Game::EvaluateGameResult(BoardMovesCount) {
+	GameResult Game::EvaluateGameResult(BoardMovesCount) const {
 		return mBoard.GetResult();
 	}
 
@@ -123,13 +118,11 @@ namespace Alphalcazar::Game {
 	PlayerId Game::GetPlayerByInitiative(bool initiative) const {
 		if (initiative) {
 			return mState.PlayerWithInitiative;
-		} else {
-			if (mState.PlayerWithInitiative == PlayerId::PLAYER_ONE) {
-				return PlayerId::PLAYER_TWO;
-			} else {
-				return PlayerId::PLAYER_ONE;
-			}
 		}
+		if (mState.PlayerWithInitiative == PlayerId::PLAYER_ONE) {
+			return PlayerId::PLAYER_TWO;
+		}
+		return PlayerId::PLAYER_ONE;
 	}
 
 	void Game::SwapPlayerWithInitiative() {

--- a/cpp/src/game/src/game/Game.cpp
+++ b/cpp/src/game/src/game/Game.cpp
@@ -97,8 +97,8 @@ namespace Alphalcazar::Game {
 
 	Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount> Game::GetLegalMoves(PlayerId player) const {
 		Utils::StaticVector<PlacementMove, c_PieceTypes* c_PerimeterTileCount> result;
-		auto legalCoordinates = mBoard.GetLegalPlacementCoordinates();
-		auto pieces = GetPiecesInHand(player);
+		const auto legalCoordinates = mBoard.GetLegalPlacementCoordinates();
+		const auto pieces = GetPiecesInHand(player);
 		for (const Coordinates& coordinates : legalCoordinates) {
 			for (const Piece& piece : pieces) {
 				result.insert({ coordinates, piece.GetType() });

--- a/cpp/src/game/src/game/PlacementMove.cpp
+++ b/cpp/src/game/src/game/PlacementMove.cpp
@@ -2,14 +2,14 @@
 
 namespace Alphalcazar::Game {
 	bool PlacementMove::Valid() const {
-		bool coordinatesValid = Coordinates.Valid();
-		bool pieceTypeValid = PieceType != 0;
+		const bool coordinatesValid = Coordinates.Valid();
+		const bool pieceTypeValid = PieceType != 0;
 		return coordinatesValid && pieceTypeValid;
 	}
 
 	bool PlacementMove::operator==(const PlacementMove& other) const {
-		bool pieceTypesMatch = PieceType == other.PieceType;
-		bool coordinatesMatch = Coordinates == other.Coordinates;
+		const bool pieceTypesMatch = PieceType == other.PieceType;
+		const bool coordinatesMatch = Coordinates == other.Coordinates;
 		return pieceTypesMatch && coordinatesMatch;
 	}
 }

--- a/cpp/src/game/tests/Board.cpp
+++ b/cpp/src/game/tests/Board.cpp
@@ -16,7 +16,7 @@ namespace Alphalcazar::Game {
 		EXPECT_EQ(board.IsFull(), false);
 		EXPECT_EQ(board.GetResult(), GameResult::NONE);
 		// We expect a square of c_PlayAreaSize size without the 4 corners
-		auto tiles = board.GetTiles();
+		const auto tiles = board.GetTiles();
 		EXPECT_EQ(tiles.size(), c_PlayAreaSize * c_PlayAreaSize - 4);
 		EXPECT_EQ(board.GetPerimeterTiles().size(), c_PerimeterTileCount);
 	}
@@ -53,9 +53,9 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, GetCompletRowResult) {
 		Board board {};
-		Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
-		Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
-		Piece pieceThree { PlayerId::PLAYER_ONE, 3 };
+		const Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
+		const Piece pieceThree { PlayerId::PLAYER_ONE, 3 };
 
 		// We complete the south-most row of the board with pieces of
 		// player 1, so that player should win
@@ -71,11 +71,11 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, GetMultiplePlayersRowResult) {
 		Board board {};
-		Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
-		Piece pieceTwo { PlayerId::PLAYER_TWO, 2 };
-		Piece pieceThree { PlayerId::PLAYER_ONE, 3 };
-		Piece pieceFour { PlayerId::PLAYER_TWO, 4 };
-		Piece pieceFive { PlayerId::PLAYER_TWO, 5 };
+		const Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceTwo { PlayerId::PLAYER_TWO, 2 };
+		const Piece pieceThree { PlayerId::PLAYER_ONE, 3 };
+		const Piece pieceFour { PlayerId::PLAYER_TWO, 4 };
+		const Piece pieceFive { PlayerId::PLAYER_TWO, 5 };
 
 		// In this test we complete a row and a diagonal in a way
 		// that both of them have pieces of both players, so no player should win
@@ -97,11 +97,11 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, GetCompletDiagonalResult) {
 		Board board {};
-		Piece pieceOne { PlayerId::PLAYER_TWO, 1 };
-		Piece pieceTwo { PlayerId::PLAYER_TWO, 2 };
-		Piece pieceThree { PlayerId::PLAYER_TWO, 3 };
-		Piece pieceFour { PlayerId::PLAYER_ONE, 4 };
-		Piece pieceFive { PlayerId::PLAYER_ONE, 5 };
+		const Piece pieceOne { PlayerId::PLAYER_TWO, 1 };
+		const Piece pieceTwo { PlayerId::PLAYER_TWO, 2 };
+		const Piece pieceThree { PlayerId::PLAYER_TWO, 3 };
+		const Piece pieceFour { PlayerId::PLAYER_ONE, 4 };
+		const Piece pieceFive { PlayerId::PLAYER_ONE, 5 };
 
 		// In this test we complete a diagonal with pieces of player 2
 		// so they should win. We afterwards place some pieces of player 1
@@ -126,7 +126,7 @@ namespace Alphalcazar::Game {
 		// First we set up a board where player 1 has completed the center
 		// column and wins. Next we set up pieces so that player 2 also completes a column
 		// and the game should result in a draw or in no result depending on if draws are accepted
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ PlayerId::PLAYER_ONE, 1, Direction::NORTH, { 2, 1 } },
 			{ PlayerId::PLAYER_ONE, 2, Direction::NORTH, { 2, 2 } },
 			{ PlayerId::PLAYER_ONE, 3, Direction::SOUTH, { 2, 3 } },
@@ -134,9 +134,9 @@ namespace Alphalcazar::Game {
 		Board board = SetupBoardForTesting(pieceSetups);
 		EXPECT_EQ(board.GetResult(), GameResult::PLAYER_ONE_WINS);
 
-		Piece pieceFour { PlayerId::PLAYER_TWO, 4 };
-		Piece pieceFive { PlayerId::PLAYER_TWO, 5 };
-		Piece pieceSix { PlayerId::PLAYER_TWO, 5 };
+		const Piece pieceFour { PlayerId::PLAYER_TWO, 4 };
+		const Piece pieceFive { PlayerId::PLAYER_TWO, 5 };
+		const Piece pieceSix { PlayerId::PLAYER_TWO, 5 };
 		board.GetTile(3, 1)->PlacePiece(pieceFour);
 		board.GetTile(3, 2)->PlacePiece(pieceFive);
 		board.GetTile(3, 3)->PlacePiece(pieceSix);
@@ -147,14 +147,14 @@ namespace Alphalcazar::Game {
 		// Piece 1 on (1,1) will move north to (1,2) (+1 movement)
 		// Piece 2 on (3,1) will move south to (3,0). Since it exited the board it is removed from play (+1 movement)
 		// Piece 5 on (2,2) will moves east to (1,2) pushing piece 1 outside the board (+2 movements)
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ PlayerId::PLAYER_ONE, c_PushablePieceType, Direction::NORTH, { 1, 1 } },
 			{ PlayerId::PLAYER_ONE, 2, Direction::SOUTH, { 3, 1 } },
 			{ PlayerId::PLAYER_TWO, 5, Direction::WEST, { 2, 2 } }
 		};
 		Board board = SetupBoardForTesting(pieceSetups);
 
-		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
+		const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
 		EXPECT_EQ(executedMoves, 4);
 
 		EXPECT_EQ(board.GetTile(1, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 5));
@@ -168,13 +168,13 @@ namespace Alphalcazar::Game {
 	TEST(Board, PushablePiecesDontPushEachOther) {
 		// Two pushable pieces are facing each other. As pushable pieces cannot
 		// push another pushable piece, we expect no movements to happen in this setup
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ PlayerId::PLAYER_ONE, c_PushablePieceType, Direction::NORTH, { 2, 2 } },
 			{ PlayerId::PLAYER_TWO, c_PushablePieceType, Direction::SOUTH, { 2, 3 } }
 		};
 		Board board = SetupBoardForTesting(pieceSetups);
 
-		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
+		const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
 		EXPECT_EQ(executedMoves, 0);
 
 		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PushablePieceType));
@@ -193,7 +193,7 @@ namespace Alphalcazar::Game {
 		 * - Piece 3 of player 2 on (3,1) will move north to (3,2) pushing piece 1 of player 2 to (3,3) (+2 movements)
 		 * - Piece 5 of player 2 on (1,4) will freely enter the board to (1,3) (+1 movement)
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ PlayerId::PLAYER_ONE, c_PushablePieceType, Direction::EAST, { 2, 1 } },
 			{ PlayerId::PLAYER_ONE, 2, Direction::NORTH, { 2, 0 } },
 
@@ -204,7 +204,7 @@ namespace Alphalcazar::Game {
 		};
 		Board board = SetupBoardForTesting(pieceSetups);
 
-		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
+		const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 		EXPECT_EQ(executedMoves, 6);
 
 		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_TWO, 2));
@@ -224,14 +224,14 @@ namespace Alphalcazar::Game {
 		// Piece 3 (1,2) moves freely to (2,2) (+1 movement)
 		// The pushing piece (1,2) moves to (2,2), pushing piece 3 to (3,2)
 		// and piece 2 outside the board (+3 movements)
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ PlayerId::PLAYER_ONE, 2, Direction::NORTH, { 3, 1 } },
 			{ PlayerId::PLAYER_ONE, 3, Direction::SOUTH, { 2, 3 } },
 			{ PlayerId::PLAYER_ONE, c_PusherPieceType, Direction::EAST, { 1, 2 } },
 		};
 		Board board = SetupBoardForTesting(pieceSetups);
 
-		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
+		const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 		EXPECT_EQ(executedMoves, 5);
 
 		EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
@@ -251,7 +251,7 @@ namespace Alphalcazar::Game {
 		{
 			// If player 2 is the starting player, we expect both pieces to push each other
 			// and end up in exactly the same positions, resulting in 4 movements (2 for each push)
-			auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
+			const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 			EXPECT_EQ(executedMoves, 4);
 
 			EXPECT_EQ(board.GetTile(2, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, c_PusherPieceType));
@@ -264,7 +264,7 @@ namespace Alphalcazar::Game {
 			// However, on the next turn, when player 1 moves first, their pushing piece on (2,2)
 			// will push the pusher of player 2 off the board, after which the pusher of player 2
 			// will not execute any movement because it will have been removed from play
-			auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
+			const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_ONE);
 			EXPECT_EQ(executedMoves, 2);
 
 			EXPECT_FALSE(board.GetTile(2, 2)->HasPiece());
@@ -288,7 +288,7 @@ namespace Alphalcazar::Game {
 		 * - Piece 4 of player 1 will not move as it has been pushed outside the board
 		 * - Piece 5 of player 1 (3,1) will move freely to (2,1) (+1 movement)
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ PlayerId::PLAYER_ONE, c_PushablePieceType, Direction::EAST, { 1, 2 } },
 			{ PlayerId::PLAYER_ONE, 2, Direction::WEST, { 3, 2 } },
 			{ PlayerId::PLAYER_ONE, c_PusherPieceType, Direction::SOUTH, { 2, 3 } },
@@ -300,7 +300,7 @@ namespace Alphalcazar::Game {
 		};
 		Board board = SetupBoardForTesting(pieceSetups);
 
-		auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
+		const auto executedMoves = board.ExecuteMoves(PlayerId::PLAYER_TWO);
 		EXPECT_EQ(executedMoves, 8);
 
 		EXPECT_EQ(board.GetTile(1, 2)->GetPiece(), Piece(PlayerId::PLAYER_ONE, 1));
@@ -315,8 +315,8 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, LegalPlacementTiles) {
 		Board board {};
-		Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
-		Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
+		const Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
 
 		auto legalPlacementTiles = board.GetLegalPlacementCoordinates();
 		// On an empty board we should have as many options as the size of the perimeter
@@ -327,17 +327,17 @@ namespace Alphalcazar::Game {
 		board.PlacePiece(legalPlacementTiles[0], pieceOne);
 		board.PlacePiece(legalPlacementTiles[1], pieceTwo);
 
-		auto legalTilesAfterPlacement = board.GetLegalPlacementCoordinates();
+		const auto legalTilesAfterPlacement = board.GetLegalPlacementCoordinates();
 		EXPECT_EQ(legalTilesAfterPlacement.size(), perimeterSize - 2);
 	}
 
 	TEST(Board, CopyPreservesState) {
 		Board board {};
-		Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
-		Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
-		Piece pieceThree { PlayerId::PLAYER_TWO, 3 };
-		Piece pieceFour { PlayerId::PLAYER_TWO, 4 };
-
+		const Piece pieceOne { PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceTwo { PlayerId::PLAYER_ONE, 2 };
+		const Piece pieceThree { PlayerId::PLAYER_TWO, 3 };
+		const Piece pieceFour { PlayerId::PLAYER_TWO, 4 };
+ 
 		board.PlacePiece({ 0, 1 }, pieceOne);
 		board.PlacePiece({ 1, 0 }, pieceTwo);
 		board.PlacePiece({ 2, 0 }, pieceThree);
@@ -357,10 +357,10 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, GetBoardPieces) {
 		Board board{};
-		Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
-		Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
-		Piece pieceFourPlayerOne{ PlayerId::PLAYER_ONE, 4 };
-		Piece pieceFourPlayerTwo{ PlayerId::PLAYER_TWO, 4 };
+		const Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
+		const Piece pieceFourPlayerOne{ PlayerId::PLAYER_ONE, 4 };
+		const Piece pieceFourPlayerTwo{ PlayerId::PLAYER_TWO, 4 };
 
 		EXPECT_EQ(board.GetPieces().size(), 0);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE).size(), 0);
@@ -374,8 +374,8 @@ namespace Alphalcazar::Game {
 
 		{
 			auto pieces = board.GetPieces();
-			auto playerOnePieces = board.GetPieces(PlayerId::PLAYER_ONE);
-			auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
+			const auto playerOnePieces = board.GetPieces(PlayerId::PLAYER_ONE);
+			const auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
 			EXPECT_EQ(pieces.size(), 4);
 			EXPECT_EQ(playerOnePieces.size(), 2);
 			EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE), 2);
@@ -388,15 +388,15 @@ namespace Alphalcazar::Game {
 		}
 
 
-		Piece pieceTwoPlayerTwo{ PlayerId::PLAYER_TWO, 2 };
-		Piece pieceThreePlayerTwo{ PlayerId::PLAYER_TWO, 3 };
+		const Piece pieceTwoPlayerTwo{ PlayerId::PLAYER_TWO, 2 };
+		const Piece pieceThreePlayerTwo{ PlayerId::PLAYER_TWO, 3 };
 		board.PlacePiece({ 1, 1 }, pieceTwoPlayerTwo, Direction::EAST);
 		board.PlacePiece({ 2, 1 }, pieceThreePlayerTwo, Direction::WEST);
 
 		{
-			auto pieces = board.GetPieces();
-			auto playerOnePieces = board.GetPieces(PlayerId::PLAYER_ONE);
-			auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
+			const auto pieces = board.GetPieces();
+			const auto playerOnePieces = board.GetPieces(PlayerId::PLAYER_ONE);
+			const auto playerTwoPieces = board.GetPieces(PlayerId::PLAYER_TWO);
 			EXPECT_EQ(pieces.size(), 6);
 			EXPECT_EQ(playerOnePieces.size(), 2);
 			EXPECT_EQ(board.GetPieceCount(PlayerId::PLAYER_ONE), 2);
@@ -407,10 +407,10 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, GetBoardPiecesWithoutPerimeter) {
 		Board board{};
-		Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
-		Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
-		Piece pieceTwoPlayerOne{ PlayerId::PLAYER_ONE, 2 };
-		Piece pieceTwoPlayerTwo{ PlayerId::PLAYER_TWO, 2 };
+		const Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
+		const Piece pieceTwoPlayerOne{ PlayerId::PLAYER_ONE, 2 };
+		const Piece pieceTwoPlayerTwo{ PlayerId::PLAYER_TWO, 2 };
 
 		// Place a player 1 piece on the perimeter
 		board.PlacePiece({ 0, 1 }, pieceOnePlayerOne);
@@ -448,13 +448,13 @@ namespace Alphalcazar::Game {
 
 	TEST(Board, GetPiecePlacements) {
 		Board board{};
-		Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
-		Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
+		const Piece pieceOnePlayerOne{ PlayerId::PLAYER_ONE, 1 };
+		const Piece pieceOnePlayerTwo{ PlayerId::PLAYER_TWO, 1 };
 
 		// Place a player 1 piece on the board
 		board.PlacePiece({ 2, 2 }, pieceOnePlayerOne, Direction::NORTH);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_ONE).size(), 1);
-		auto playerOnePlacements = board.GetPiecePlacements(PlayerId::PLAYER_ONE);
+		const auto playerOnePlacements = board.GetPiecePlacements(PlayerId::PLAYER_ONE);
 		for (std::size_t i = 0; i < playerOnePlacements.size(); i++) {
 			EXPECT_TRUE(i == 0 ? playerOnePlacements[i] : !playerOnePlacements[i]);
 		}
@@ -462,7 +462,7 @@ namespace Alphalcazar::Game {
 		// Place a player 2 piece on the board
 		board.PlacePiece({ 2, 3 }, pieceOnePlayerTwo, Direction::NORTH);
 		EXPECT_EQ(board.GetPieces(PlayerId::PLAYER_TWO).size(), 1);
-		auto playerTwoPlacements = board.GetPiecePlacements(PlayerId::PLAYER_TWO);
+		const auto playerTwoPlacements = board.GetPiecePlacements(PlayerId::PLAYER_TWO);
 		for (std::size_t i = 0; i < playerTwoPlacements.size(); i++) {
 			EXPECT_TRUE(i == 0 ? playerTwoPlacements[i] : !playerTwoPlacements[i]);
 		}

--- a/cpp/src/game/tests/Game.cpp
+++ b/cpp/src/game/tests/Game.cpp
@@ -8,12 +8,10 @@
 #include "game/PlacementMove.hpp"
 #include "game/parameters.hpp"
 
-#include "testhelpers.hpp"
-
 namespace Alphalcazar::Game {
 	class MockStrategy final : public Strategy {
 	public:
-		virtual PlacementMove Execute(PlayerId playerId, const Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount>&, const Game&) override {
+		PlacementMove Execute(PlayerId playerId, const Utils::StaticVector<PlacementMove, c_MaxLegalMovesCount>&, const Game&) override {
 			if (playerId == PlayerId::PLAYER_ONE) {
 				return { { 0, 2 }, 3 };
 			}
@@ -22,7 +20,7 @@ namespace Alphalcazar::Game {
 	};
 
 	TEST(Game, InitialGameState) {
-		Game game{};
+		const Game game{};
 
 		EXPECT_EQ(game.GetActivePlayer(), PlayerId::PLAYER_ONE);
 		EXPECT_EQ(game.GetPlayerByInitiative(true), PlayerId::PLAYER_ONE);

--- a/cpp/src/game/tests/testhelpers.hpp
+++ b/cpp/src/game/tests/testhelpers.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "game/Game.hpp"
 #include "game/Board.hpp"
 #include "game/Coordinates.hpp"

--- a/cpp/src/main/main.cpp
+++ b/cpp/src/main/main.cpp
@@ -6,31 +6,42 @@
 
 #include <chrono>
 
-std::uint64_t executionTime(std::function<void()> function) {
-	auto start = std::chrono::high_resolution_clock::now();
+std::uint64_t executionTime(const std::function<void()>& function) {
+	const auto start = std::chrono::high_resolution_clock::now();
 	function();
-	auto end = std::chrono::high_resolution_clock::now();
+	const auto end = std::chrono::high_resolution_clock::now();
 	return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 }
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
+void runMinMaxFirstTurnBenchmark(const Alphalcazar::Game::Game& game, Alphalcazar::Strategy::MinMax::Depth depth, bool multithreaded) {
+	Alphalcazar::Strategy::MinMax::MinMaxStrategy strategy{ depth, multithreaded };
+	const auto executionTimeMs = executionTime([&strategy, &game]() {
+		strategy.Execute(Alphalcazar::Game::PlayerId::PLAYER_ONE, game.GetLegalMoves(Alphalcazar::Game::PlayerId::PLAYER_ONE), game);
+	});
+	const auto score = strategy.GetLastExecutedMoveScore();
+	Alphalcazar::Utils::LogInfo("First move at depth {} took {}ms and calculated a score of {}", depth, executionTimeMs, score);
+}
+
+void runMinMaxFullGameBenchmark(Alphalcazar::Game::Game& game, Alphalcazar::Strategy::MinMax::Depth depth, bool multithreaded) {
+	Alphalcazar::Strategy::MinMax::MinMaxStrategy strategy{ depth, multithreaded };
+	Alphalcazar::Game::GameResult result = Alphalcazar::Game::GameResult::NONE;
+	const auto executionTimeMs = executionTime([&strategy, &game, &result]() {
+		result = game.Play(strategy, strategy);
+	});
+	Alphalcazar::Utils::LogInfo("Game at depth {} took {}ms ended with result {}", depth, executionTimeMs, static_cast<int>(result));
+}
+
+void runMinMaxBenchmarks() {
 	constexpr Alphalcazar::Strategy::MinMax::Depth c_MaxDepth = 5;
+	constexpr bool c_MultithreadedBenchmark = true;
 	for (Alphalcazar::Strategy::MinMax::Depth depth = 1; depth <= c_MaxDepth; depth++) {
-		Alphalcazar::Strategy::MinMax::MinMaxStrategy strategy{ depth, true };
 		Alphalcazar::Game::Game game{};
-		auto firstTurnExecutionTimeMs = executionTime([&strategy, &game]() {
-			strategy.Execute(Alphalcazar::Game::PlayerId::PLAYER_ONE, game.GetLegalMoves(Alphalcazar::Game::PlayerId::PLAYER_ONE), game);
-		});
-		auto score = strategy.GetLastExecutedMoveScore();
-		Alphalcazar::Utils::LogInfo("First move at depth {} took {}ms and calculated a score of {}", depth, firstTurnExecutionTimeMs, score);
-
-		Alphalcazar::Strategy::MinMax::MinMaxStrategy fullGameStrategy{ depth, true };
-		Alphalcazar::Game::GameResult result = Alphalcazar::Game::GameResult::NONE;
-		auto fullGameExecutionTime = executionTime([&fullGameStrategy, &game, &result]() {
-			result = game.Play(fullGameStrategy, fullGameStrategy);
-		});
-		Alphalcazar::Utils::LogInfo("Game at depth {} took {}ms ended with result {}", depth, fullGameExecutionTime, static_cast<int>(result));
+		runMinMaxFirstTurnBenchmark(game, depth, c_MultithreadedBenchmark);
+		runMinMaxFullGameBenchmark(game, depth, c_MultithreadedBenchmark);
 	}
+}
 
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
+	runMinMaxBenchmarks();
 	return 0;
 }

--- a/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/LegalMovements.hpp
@@ -6,8 +6,6 @@
 #include <util/StaticVector.hpp>
 #include <game/PlacementMove.hpp>
 
-#include <tuple>
-
 namespace Alphalcazar::Game {
 	class Board;
 }
@@ -15,9 +13,9 @@ namespace Alphalcazar::Game {
 namespace Alphalcazar::Strategy::MinMax {
 	/// A small extension of the \ref PlacementMove data structure adding a heuristic score for quicker sorting
 	struct ScoredPlacementMove final : public Game::PlacementMove {
-		ScoredPlacementMove() {}
-		ScoredPlacementMove(const Game::PlacementMove& placementMove) 
-			: Game::PlacementMove{ placementMove }
+		ScoredPlacementMove() = default;
+		ScoredPlacementMove(const PlacementMove& placementMove) 
+			: PlacementMove{ placementMove }
 		{}
 
 		/// The heuristic score calculated for this placement move
@@ -54,7 +52,7 @@ namespace Alphalcazar::Strategy::MinMax {
 
 // We define the specializations of parse & format to make \ref ScoredPlacementMove formattable. Based on: https://fmt.dev/latest/api.html#format-api
 template <> struct fmt::formatter<Alphalcazar::Strategy::MinMax::ScoredPlacementMove> {
-	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+	constexpr auto parse(const format_parse_context& ctx) -> decltype(ctx.begin()) {
 		return ctx.begin();
 	}
 

--- a/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/MinMaxStrategy.hpp
@@ -29,10 +29,10 @@ namespace Alphalcazar::Strategy::MinMax {
 	 */
 	class MinMaxStrategy final : public Game::Strategy {
 	public:
-		MinMaxStrategy(const Depth depth, bool multithreaded = true);
-		~MinMaxStrategy();
+		MinMaxStrategy(Depth depth, bool multithreaded = true);
+		~MinMaxStrategy() override;
 
-		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game& game) override;
+		Game::PlacementMove Execute(Game::PlayerId playerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game& game) override;
 
 		/// Returns the score calculated for the move returned by the last \ref Execute function call
 		Score GetLastExecutedMoveScore() const;

--- a/cpp/src/strategies/minmax/include/minmax/config.hpp
+++ b/cpp/src/strategies/minmax/include/minmax/config.hpp
@@ -2,7 +2,6 @@
 
 #include "minmax/minmax_aliases.hpp"
 #include "game/parameters.hpp"
-#include "game/Coordinates.hpp"
 
 #include <array>
 
@@ -19,9 +18,9 @@ namespace Alphalcazar::Strategy::MinMax {
 	 *
 	 * This will ensure that if several moves lead to the same position/result (a win, for example), the
 	 * move that achieves this in the least amount of moves will be chosen. On the contrary, this will ensure
-	 * that an inevitable loss will be posponed as much as possible.
+	 * that an inevitable loss will be postponed as much as possible.
 	 *
-	 * \note The value of this penalty should be low enough to never have an impact on the score appart
+	 * \note The value of this penalty should be low enough to never have an impact on the score apart
 	 * from deciding between moves with equal score but different depth.
 	 */
 	constexpr Score c_DepthScorePenalty = 1;

--- a/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/BoardEvaluation.cpp
@@ -17,25 +17,28 @@ namespace Alphalcazar::Strategy::MinMax {
 	float GetPieceScoreMultiplier(const Game::Coordinates& coordinates, Game::Direction direction) {
 		if (coordinates.IsCenter()) {
 			return c_CenterPieceMultiplier;
-		} else if (coordinates.IsBoardCorner()) {
+		}
+		
+		if (coordinates.IsBoardCorner()) {
 			// In the board corners, a piece can only have recently entered the board
 			// or be about to leave it
-			auto pieceTargetCoordinate = coordinates.GetCoordinateInDirection(direction, 1);
+			const auto pieceTargetCoordinate = coordinates.GetCoordinateInDirection(direction, 1);
 			if (pieceTargetCoordinate.IsPerimeter()) {
 				return c_PieceAboutToExitMultiplier;
-			} else {
-				return c_FreshCornerPieceMultiplier;
 			}
-		} else {
-			// The piece is on one of the center lanes, but not in the center tile
-			auto pieceTargetCoordinate = coordinates.GetCoordinateInDirection(direction, 1);
-			if (pieceTargetCoordinate.IsPerimeter()) {
-				// The piece is about to exit the board
-				return c_PieceAboutToExitMultiplier;
-			} else if (pieceTargetCoordinate.IsCenter()) {
-				// The piece just entered the center lane and wants to move to the center
-				return c_FreshCenterLanePieceMultiplier;
-			}
+			return c_FreshCornerPieceMultiplier;
+		}
+		
+		// The piece is on one of the center lanes, but not in the center tile
+		const auto pieceTargetCoordinate = coordinates.GetCoordinateInDirection(direction, 1);
+		if (pieceTargetCoordinate.IsPerimeter()) {
+			// The piece is about to exit the board
+			return c_PieceAboutToExitMultiplier;
+		}
+		
+		if (pieceTargetCoordinate.IsCenter()) {
+			// The piece just entered the center lane and wants to move to the center
+			return c_FreshCenterLanePieceMultiplier;
 		}
 		return 1.f;
 	}
@@ -60,13 +63,13 @@ namespace Alphalcazar::Strategy::MinMax {
 		for (std::size_t i = 0; i < piecesCount; ++i) {
 			auto& [coordinates, piece] = pieces[i];
 			if (!coordinates.IsPerimeter()) {
-				auto direction = piece.GetMovementDirection();
-				float pieceScoreMultiplier = GetPieceScoreMultiplier(coordinates, direction);
+				const Game::Direction direction = piece.GetMovementDirection();
+				const float pieceScoreMultiplier = GetPieceScoreMultiplier(coordinates, direction);
 
 				// The piece on board score array stores all piece types in order, meaning that
 				// the score of a certain piece type will be located at index (type - 1)
-				Score pieceOnBoardScore = c_PieceOnBoardScores[piece.GetType() - 1];
-				Score pieceScore = static_cast<Score>(pieceOnBoardScore * pieceScoreMultiplier);
+				const Score pieceOnBoardScore = c_PieceOnBoardScores[piece.GetType() - 1];
+				const Score pieceScore = static_cast<Score>(pieceOnBoardScore * pieceScoreMultiplier);
 
 				// Add the score if the piece belongs to the player for which we are evaluating the score
 				// or subtract it if it belongs to the opponent
@@ -81,8 +84,8 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	Score GetDepthAdjustedScore(Score score, Depth depth) {
-		Score depthPenalty = depth * c_DepthScorePenalty;
-		Score penalty = std::min(depthPenalty, static_cast<Score>(std::abs(score)));
+		const Score depthPenalty = depth * c_DepthScorePenalty;
+		const Score penalty = std::min(depthPenalty, std::abs(score));
 		if (score > 0) {
 			score -= penalty;
 		} else {

--- a/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
@@ -49,7 +49,7 @@ namespace Alphalcazar::Strategy::MinMax {
 			moveFutures.reserve(candidateMoves.size());
 			for (const auto& move : candidateMoves) {
 				auto moveFuture = mThreadPool->Execute([this, playerId, move, game]() -> MoveFutureResult {
-					auto moveScore = GetNextBestScore(playerId, move, mDepth, game, mFirstLevelAlpha, c_BetaStartingValue);
+					const auto moveScore = GetNextBestScore(playerId, move, mDepth, game, mFirstLevelAlpha, c_BetaStartingValue);
 					mFirstLevelAlpha = std::max(mFirstLevelAlpha.load(), moveScore);
 					return std::make_pair(moveScore, move);
 				});

--- a/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/src/minmax/MinMaxStrategy.cpp
@@ -95,7 +95,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		const auto legalMoves = game.GetLegalMoves(playerId);
 		auto candidateMoves = SortAndFilterMovements(playerId, legalMoves, game.GetBoard());
 		for (const auto& move : candidateMoves) {
-			auto nextBestScore = GetNextBestScore(playerId, move, depth, game, alpha, beta);
+			const auto nextBestScore = GetNextBestScore(playerId, move, depth, game, alpha, beta);
 
 			bestScore = std::max(nextBestScore, bestScore);
 			alpha = std::max(bestScore, alpha);
@@ -120,7 +120,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		const auto legalMoves = game.GetLegalMoves(opponentId);
 		auto candidateMoves = SortAndFilterMovements(playerId, legalMoves, game.GetBoard());
 		for (const auto& move : candidateMoves) {
-			auto nextBestScore = GetNextBestScore(playerId, move, depth, game, alpha, beta);
+			const auto nextBestScore = GetNextBestScore(playerId, move, depth, game, alpha, beta);
 			bestScore = std::min(nextBestScore, bestScore);
 			beta = std::min(bestScore, beta);
 			if (beta < alpha) {

--- a/cpp/src/strategies/minmax/tests/BoardEvaluation.cpp
+++ b/cpp/src/strategies/minmax/tests/BoardEvaluation.cpp
@@ -4,50 +4,48 @@
 #include "minmax/config.hpp"
 
 #include <game/Game.hpp>
-#include <game/Tile.hpp>
-#include <game/Piece.hpp>
 
 #include "setuphelpers.hpp"
 
 namespace Alphalcazar::Strategy::MinMax {
 	TEST(BoardEvaluation, EvaluateBoard) {
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ Game::PlayerId::PLAYER_ONE, 1, Game::Direction::NORTH, { 2, 2 } },
 			{ Game::PlayerId::PLAYER_ONE, 5, Game::Direction::WEST, { 1, 1 } },
 		};
-		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
+		const Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
-		Score score = EvaluateBoard(Game::PlayerId::PLAYER_ONE, game);
-		Score opponentScore = EvaluateBoard(Game::PlayerId::PLAYER_TWO, game);
+		const Score score = EvaluateBoard(Game::PlayerId::PLAYER_ONE, game);
+		const Score opponentScore = EvaluateBoard(Game::PlayerId::PLAYER_TWO, game);
 
 		EXPECT_EQ(score, c_PieceOnBoardScores[0] * c_CenterPieceMultiplier + c_PieceOnBoardScores[4] * c_PieceAboutToExitMultiplier);
 		EXPECT_EQ(score, -opponentScore);
 	}
 
 	TEST(BoardEvaluation, EvaluatePieceLifeTime) {
-		std::vector<PieceSetup> perimeterPieceSetups {
+		const std::vector<PieceSetup> perimeterPieceSetups {
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 0 } },
 		};
-		Game::Game perimeterGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, perimeterPieceSetups);
-		Score perimeterScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, perimeterGame);
+		const Game::Game perimeterGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, perimeterPieceSetups);
+		const Score perimeterScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, perimeterGame);
 
-		std::vector<PieceSetup> justEnteredPieceSetups{
+		const std::vector<PieceSetup> justEnteredPieceSetups{
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 1 } },
 		};
-		Game::Game justEnteredGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, justEnteredPieceSetups);
-		Score justEnteredScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, justEnteredGame);
+		const Game::Game justEnteredGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, justEnteredPieceSetups);
+		const Score justEnteredScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, justEnteredGame);
 
-		std::vector<PieceSetup> centerTilePieceSetups{
+		const std::vector<PieceSetup> centerTilePieceSetups{
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 2 } },
 		};
-		Game::Game centerTileGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, centerTilePieceSetups);
-		Score centerTileScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, centerTileGame);
+		const Game::Game centerTileGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, centerTilePieceSetups);
+		const Score centerTileScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, centerTileGame);
 
-		std::vector<PieceSetup> aboutToExitPieceSetups{
+		const std::vector<PieceSetup> aboutToExitPieceSetups{
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::NORTH, { 1, 3 } },
 		};
-		Game::Game aboutToExitGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, aboutToExitPieceSetups);
-		Score aboutToExitScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, aboutToExitGame);
+		const Game::Game aboutToExitGame = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, aboutToExitPieceSetups);
+		const Score aboutToExitScore = EvaluateBoard(Game::PlayerId::PLAYER_ONE, aboutToExitGame);
 
 		// Pieces on the perimeter don't contribute to score
 		EXPECT_EQ(perimeterScore, 0);

--- a/cpp/src/strategies/minmax/tests/LegalMovements.cpp
+++ b/cpp/src/strategies/minmax/tests/LegalMovements.cpp
@@ -5,7 +5,6 @@
 
 #include <game/Game.hpp>
 #include <game/Piece.hpp>
-#include <game/Tile.hpp>
 #include <game/Board.hpp>
 #include <game/parameters.hpp>
 #include <game/PlacementMove.hpp>
@@ -21,7 +20,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		EXPECT_TRUE(xSymmetryEmpty);
 		EXPECT_TRUE(ySymmetryEmpty);
 
-		Game::Piece pieceOne { Game::PlayerId::PLAYER_ONE, 1 };
+		const Game::Piece pieceOne { Game::PlayerId::PLAYER_ONE, 1 };
 		game.GetBoard().PlacePiece({ 2, 2 }, pieceOne, Game::Direction::NORTH);
 
 		// A piece in the center pointing north should create Y symmetry
@@ -29,7 +28,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		EXPECT_FALSE(xSymmetryCenterPiece);
 		EXPECT_TRUE(ySymmetryCenterPiece);
 
-		Game::Piece pieceTwo { Game::PlayerId::PLAYER_ONE, 2 };
+		const Game::Piece pieceTwo { Game::PlayerId::PLAYER_ONE, 2 };
 		game.GetBoard().PlacePiece({ 2, 3 }, pieceTwo, Game::Direction::EAST);
 
 		// Once we have added a second piece, still in the center row but facing east, all symmetries should be broken
@@ -39,7 +38,7 @@ namespace Alphalcazar::Strategy::MinMax {
 	}
 
 	TEST(LegalMovements, CornerSymmetries) {
-		std::vector<PieceSetup> pieceSetups{
+		const std::vector<PieceSetup> pieceSetups{
 			{ Game::PlayerId::PLAYER_ONE, 1, Game::Direction::NORTH, { 1, 1 } },
 		};
 		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);

--- a/cpp/src/strategies/minmax/tests/MinMaxStrategy.cpp
+++ b/cpp/src/strategies/minmax/tests/MinMaxStrategy.cpp
@@ -4,8 +4,6 @@
 #include "minmax/config.hpp"
 
 #include <game/Game.hpp>
-#include <game/Tile.hpp>
-#include <game/Piece.hpp>
 #include <game/parameters.hpp>
 #include <game/PlacementMove.hpp>
 
@@ -23,7 +21,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		 * It's the only winning move as the (3,2) is about to be occupied by the opponent's 3,
 		 * and the 2 piece is the only non-pushable piece player 2 has that moves before that 3 piece.
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ Game::PlayerId::PLAYER_TWO, 3, Game::Direction::NORTH, { 1, 1 } },
 			{ Game::PlayerId::PLAYER_TWO, 4, Game::Direction::NORTH, { 2, 1 } },
 
@@ -33,7 +31,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		// Results should be the same independently of depth
-		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
+		const auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
 		Game::Coordinates winningCoordinates { 4, 2 };
 		for (Depth depth = 1; depth <= 2; depth++) {
 			MinMaxStrategy strategy { depth };
@@ -59,15 +57,15 @@ namespace Alphalcazar::Strategy::MinMax {
 		 * If the movement is not blocked, player 2 can win by playing anything on (2,4). The only way for player 2 to
 		 * avoid an immediate loss is to play any piece on (2,4).
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ Game::PlayerId::PLAYER_ONE, 5, Game::Direction::EAST, { 1, 1 } },
 			{ Game::PlayerId::PLAYER_ONE, 4, Game::Direction::WEST, { 3, 2 } },
 
 			{ Game::PlayerId::PLAYER_TWO, 4, Game::Direction::WEST, { 1, 2 } }
 		};
-		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_TWO, false, pieceSetups);
+		const Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_TWO, false, pieceSetups);
 
-		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
+		const auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
 
 		// Player 2 should decide to play a piece on the (2,4) square regardless of the search depth
 		// and regardless of if the strategy is executed on multiple or a single thread
@@ -103,7 +101,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		 * enough as player 1 does not have the innitiative this turn. The only piece that can move before the opponent's
 		 * 2 and 3 is the 1 piece, which will be pushed and won't prevent the loss.
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ Game::PlayerId::PLAYER_TWO, 5, Game::Direction::SOUTH, { 2, 3 } },
 			{ Game::PlayerId::PLAYER_TWO, 2, Game::Direction::SOUTH, { 3, 3 } },
 			{ Game::PlayerId::PLAYER_TWO, 3, Game::Direction::NORTH, { 1, 1 } },
@@ -112,12 +110,12 @@ namespace Alphalcazar::Strategy::MinMax {
 
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::WEST, { 1, 3 } }
 		};
-		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_TWO, true, pieceSetups);
+		const Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_TWO, true, pieceSetups);
 
-		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE);
+		const auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE);
 
 		MinMaxStrategy strategy { 1 };
-		auto move = strategy.Execute(Game::PlayerId::PLAYER_ONE, legalMoves, game);
+		const auto move = strategy.Execute(Game::PlayerId::PLAYER_ONE, legalMoves, game);
 
 		// Positions at which the pushing piece can be played to avoid an immediate loss
 		std::vector<Game::Coordinates> expectedCoordinates {
@@ -135,7 +133,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		 * They can avoid losing this round by playing the pushing piece at (2,0), but next round they will
 		 * be unable to block both squares where P1 can mate, and will not have the pushing piece in hand.
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::SOUTH, { 2, 3 } },
 			{ Game::PlayerId::PLAYER_ONE, 3, Game::Direction::EAST, { 1, 2 } },
 			// The first move played this turn
@@ -146,11 +144,11 @@ namespace Alphalcazar::Strategy::MinMax {
 		};
 		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
-		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
+		const auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
 
-		Game::Coordinates expectedCoordinates = { 2, 0 };
-		Game::PieceType expectedPieceType = Game::c_PusherPieceType;
-		Score expectedScore = -c_WinConditionScore + c_DepthScorePenalty;
+		constexpr Game::Coordinates expectedCoordinates = { 2, 0 };
+		constexpr Game::PieceType expectedPieceType = Game::c_PusherPieceType;
+		constexpr Score expectedScore = -c_WinConditionScore + c_DepthScorePenalty;
 		{
 			MinMaxStrategy strategy{ 2 };
 			auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
@@ -165,7 +163,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		// At depth 3, the strategy should return exactly the same result
 		{
 			MinMaxStrategy strategy{ 3 };
-			auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
+			const auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
 
 			EXPECT_EQ(move.PieceType, expectedPieceType);
 			EXPECT_TRUE(move.Coordinates.x == expectedCoordinates.x && move.Coordinates.y == expectedCoordinates.y);
@@ -186,7 +184,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		 * They only has piece 5 in hand, and as long as they keeps it for the next move (makes it not enter the board)
 		 * they will be able to use it next round to win the game, no reply from player 1 possible.
 		 */
-		std::vector<PieceSetup> pieceSetups {
+		const std::vector<PieceSetup> pieceSetups {
 			{ Game::PlayerId::PLAYER_ONE, 1, Game::Direction::EAST, { 2, 3 } },
 			{ Game::PlayerId::PLAYER_ONE, 2, Game::Direction::WEST, { 3, 2 } },
 			// The first move played this turn
@@ -199,11 +197,11 @@ namespace Alphalcazar::Strategy::MinMax {
 			{ Game::PlayerId::PLAYER_TWO, 3, Game::Direction::WEST, { 3, 3 } },
 			{ Game::PlayerId::PLAYER_TWO, 4, Game::Direction::EAST, { 2, 2 } }
 		};
-		Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
+		const Game::Game game = SetupGameForMinMaxTesting(Game::PlayerId::PLAYER_ONE, true, pieceSetups);
 
 		MinMaxStrategy strategy { 2 };
-		auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
-		auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
+		const auto legalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO);
+		const auto move = strategy.Execute(Game::PlayerId::PLAYER_TWO, legalMoves, game);
 
 		// These are the perimeter tiles at which placing the 5 piece would cause it to enter the board
 		// Player 2 must place the piece on any tile except these ones to be able to win next round.

--- a/cpp/src/strategies/minmax/tests/setuphelpers.cpp
+++ b/cpp/src/strategies/minmax/tests/setuphelpers.cpp
@@ -9,7 +9,7 @@ namespace Alphalcazar::Strategy::MinMax {
 		game.GetState().FirstMoveExecuted = firstMoveExecuted;
 		game.GetState().PlayerWithInitiative = playerWithInitiative;
 
-		for (auto& pieceSetup : pieceSetups) {
+		for (const auto& pieceSetup : pieceSetups) {
 			Game::Piece piece{ pieceSetup.PlayerId, pieceSetup.PieceType };
 			game.GetBoard().PlacePiece(pieceSetup.Coordinates, piece, pieceSetup.Direction);
 		}

--- a/cpp/src/strategies/minmax/tests/setuphelpers.hpp
+++ b/cpp/src/strategies/minmax/tests/setuphelpers.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <game/Game.hpp>
 #include <game/aliases.hpp>
 

--- a/cpp/src/strategies/random/include/random/RandomStrategy.hpp
+++ b/cpp/src/strategies/random/include/random/RandomStrategy.hpp
@@ -19,7 +19,7 @@ namespace Alphalcazar::Strategy::Random {
 	class RandomStrategy final : public Game::Strategy {
 	public:
 		RandomStrategy();
-		virtual Game::PlacementMove Execute(Game::PlayerId playerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game& game) override;
+		Game::PlacementMove Execute(Game::PlayerId playerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game& game) override;
 	private:
 		std::random_device mRandomDevice;
 		std::mt19937 mRandomEngine;

--- a/cpp/src/strategies/random/src/random/RandomStrategy.cpp
+++ b/cpp/src/strategies/random/src/random/RandomStrategy.cpp
@@ -5,8 +5,7 @@
 
 namespace Alphalcazar::Strategy::Random {
 	RandomStrategy::RandomStrategy() 
-		: mRandomDevice {}
-		, mRandomEngine { mRandomDevice() }
+		: mRandomEngine { mRandomDevice() }
 	{}
 
 	Game::PlacementMove RandomStrategy::Execute(Game::PlayerId, const Utils::StaticVector<Game::PlacementMove, Game::c_MaxLegalMovesCount>& legalMoves, const Game::Game&) {

--- a/cpp/src/strategies/random/tests/RandomStrategy.cpp
+++ b/cpp/src/strategies/random/tests/RandomStrategy.cpp
@@ -15,16 +15,16 @@ namespace Alphalcazar::Strategy::Random {
 			Game::Game game {};
 			const auto& board = game.GetBoard();
 			const auto perimeterTilesCount = game.GetBoard().GetPerimeterTiles().size();
-			auto initialLegalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE).size();
+			const auto initialLegalMoves = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE).size();
 
 			auto result = game.PlayTurn(strategy, strategy);
 			EXPECT_EQ(result, Game::GameResult::NONE);
 			EXPECT_EQ(board.IsFull(), false);
 			// The amount of legal moves for at least one player will have decreased by the amount of perimeter tiles there are
 			// as they will have 1 piece less in hand
-			auto playerOneMovesCount = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE).size();
-			auto playerTwoMovesCount = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO).size();
-			auto expectedLegalMoves = initialLegalMoves - perimeterTilesCount;
+			const auto playerOneMovesCount = game.GetLegalMoves(Game::PlayerId::PLAYER_ONE).size();
+			const auto playerTwoMovesCount = game.GetLegalMoves(Game::PlayerId::PLAYER_TWO).size();
+			const auto expectedLegalMoves = initialLegalMoves - perimeterTilesCount;
 			EXPECT_TRUE(playerOneMovesCount == expectedLegalMoves || playerTwoMovesCount == expectedLegalMoves);
 
 			// After a single turn has been played, we expect either 2 or 1 pieces on the board 
@@ -41,10 +41,10 @@ namespace Alphalcazar::Strategy::Random {
 
 	TEST(RandomStrategy, TestRandomGames) {
 		RandomStrategy strategy {};
-		// We run a 100 random games as a santity check that the game works correctly
+		// We run a 100 random games as a sanity check that the game works correctly
 		for (std::size_t i = 0; i <= 100; i++) {
 			Game::Game game {};
-			auto result = game.Play(strategy, strategy);
+			const auto result = game.Play(strategy, strategy);
 			const auto& state = game.GetState();
 			// Validate that the strategy ends up with a valid game result
 			EXPECT_TRUE(result == Game::GameResult::DRAW || result == Game::GameResult::PLAYER_ONE_WINS || result == Game::GameResult::PLAYER_TWO_WINS);

--- a/cpp/src/util/include/util/ThreadPool.hpp
+++ b/cpp/src/util/include/util/ThreadPool.hpp
@@ -32,7 +32,7 @@ namespace Alphalcazar::Utils {
         /// A virtual class to allow storing multiple specialized \ref TaskContainerBase in the same queue
         class TaskContainerBase {
         public:
-            virtual ~TaskContainerBase() {};
+            virtual ~TaskContainerBase() = default;
             virtual void Execute() = 0;
         };
 
@@ -76,7 +76,7 @@ namespace Alphalcazar::Utils {
     auto ThreadPool::Execute(F function) {
         static_assert(!std::is_function_v<F>, "ThreadPool::Execute function type needs to be callable.");
 
-        std::unique_lock<std::mutex> queueLock{ mTaskMutex, std::defer_lock };
+        std::unique_lock queueLock{ mTaskMutex, std::defer_lock };
         std::packaged_task<std::invoke_result_t<F>()> packagedTask{ std::bind(function) };
         std::future<std::invoke_result_t<F>> future = packagedTask.get_future();
 

--- a/cpp/src/util/src/util/ThreadPool.cpp
+++ b/cpp/src/util/src/util/ThreadPool.cpp
@@ -5,8 +5,8 @@ namespace Alphalcazar::Utils {
         mThreads.reserve(threadCount);
         for (size_t i = 0; i < threadCount; i++) {
             mThreads.emplace_back(
-                std::thread([this]() {
-                    std::unique_lock<std::mutex> queueLock{ mTaskMutex, std::defer_lock };
+                [this]() {
+                    std::unique_lock queueLock{ mTaskMutex, std::defer_lock };
 
                     while (true) {
                         queueLock.lock();
@@ -16,14 +16,14 @@ namespace Alphalcazar::Utils {
 
                         if (mThreadsStopping && mTasks.empty()) return;
 
-                        std::unique_ptr<TaskContainerBase> task = std::move(mTasks.front());
+                        const std::unique_ptr<TaskContainerBase> task = std::move(mTasks.front());
 
                         mTasks.pop();
                         queueLock.unlock();
 
                         task->Execute();
                     }
-                })
+                }
             );
         }
     }


### PR DESCRIPTION
Before:
```
First move at depth 1 took 8ms and calculated a score of 0
Game at depth 1 took 1ms ended with result 3
First move at depth 2 took 5ms and calculated a score of -34
Game at depth 2 took 24ms ended with result 3
First move at depth 3 took 178ms and calculated a score of 35
Game at depth 3 took 1644ms ended with result 2
First move at depth 4 took 22136ms and calculated a score of -64

```

After:
```
First move at depth 1 took 8ms and calculated a score of 0
Game at depth 1 took 1ms ended with result 3
First move at depth 2 took 4ms and calculated a score of -34
Game at depth 2 took 21ms ended with result 3
First move at depth 3 took 158ms and calculated a score of 35
Game at depth 3 took 1628ms ended with result 2
First move at depth 4 took 21536ms and calculated a score of -64
```