### PR TITLE
Allow early-exiting board tile loops

### DIFF
--- a/cpp/src/game/include/game/Board.hpp
+++ b/cpp/src/game/include/game/Board.hpp
@@ -128,10 +128,14 @@ namespace Alphalcazar::Game {
 		 *       first and the movement of the pushing piece last).
 		 */
 		Utils::ReversedStaticVector<Board::MovementDescription, c_PlayAreaSize> GetChainedPushMovements(const Coordinates& sourceCoordinates, Direction direction);
-
-		/// Executes a specified function for every tile of this board
-		void LoopOverTiles(const std::function<void(const Coordinates& coordinates, const Tile& tile)>& action) const;
-		void LoopOverTiles(const std::function<void(const Coordinates& coordinates, Tile& tile)>& action);
+		
+		/*!
+		 * \brief Executes a specified function for every tile of this board.
+		 *
+		 * \param action The function to execute for each tile. If it returns true, the loop will be interrupted.
+		 */
+		void LoopOverTiles(const std::function<bool(const Coordinates& coordinates, const Tile& tile)>& action) const;
+		void LoopOverTiles(const std::function<bool(const Coordinates& coordinates, Tile& tile)>& action);
 
 		/// Get the coordinates at which a given piece is placed on the board. Returns invalid coordinates if the piece does not exist on the board.
 		Coordinates& GetPlacedPieceCoordinates(const Piece& piece);

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -409,7 +409,7 @@ namespace Alphalcazar::Game {
 	void Board::LoopOverTiles(const std::function<bool(const Coordinates& coordinates, Tile& tile)>& action) {
 		for (Coordinate x = 0; x <= c_PlayAreaSize - 1; x++) {
 			for (Coordinate y = 0; y <= c_PlayAreaSize - 1; y++) {
-				Coordinates coordinates { x, y };
+				const Coordinates coordinates { x, y };
 				if (coordinates.IsCorner()) {
 					// The corners of the play area don't exist
 					continue;

--- a/cpp/src/game/src/game/Board.cpp
+++ b/cpp/src/game/src/game/Board.cpp
@@ -218,6 +218,7 @@ namespace Alphalcazar::Game {
 		LoopOverTiles([&result, &index](const Coordinates&, const Tile& tile) {
 			result[index] = &tile;
 			++index;
+			return false;
 		});
 		return result;
 	}
@@ -230,6 +231,7 @@ namespace Alphalcazar::Game {
 				result[index] = &tile;
 				++index;
 			}
+			return false;
 		});
 		return result;
 	}
@@ -252,8 +254,9 @@ namespace Alphalcazar::Game {
 			// If we find a single non-perimeter file that has no piece on it, we return false
 			if (!coordinates.IsPerimeter() && !tile.HasPiece()) {
 				result = false;
-				return;
+				return true;
 			}
+			return false;
 		});
 		return result;
 	}
@@ -388,20 +391,22 @@ namespace Alphalcazar::Game {
 		return result;
 	}
 
-	void Board::LoopOverTiles(const std::function<void(const Coordinates& coordinates, const Tile& tile)>& action) const {
+	void Board::LoopOverTiles(const std::function<bool(const Coordinates& coordinates, const Tile& tile)>& action) const {
 		for (Coordinate x = 0; x <= c_PlayAreaSize - 1; x++) {
 			for (Coordinate y = 0; y <= c_PlayAreaSize - 1; y++) {
-				Coordinates coordinates { x, y };
+				const Coordinates coordinates { x, y };
 				if (coordinates.IsCorner()) {
 					// The corners of the play area don't exist
 					continue;
 				}
-				action(coordinates, mTiles[x][y]);
+				if (action(coordinates, mTiles[x][y])) {
+					return;
+				}
 			}
 		}
 	}
 
-	void Board::LoopOverTiles(const std::function<void(const Coordinates& coordinates, Tile& tile)>& action) {
+	void Board::LoopOverTiles(const std::function<bool(const Coordinates& coordinates, Tile& tile)>& action) {
 		for (Coordinate x = 0; x <= c_PlayAreaSize - 1; x++) {
 			for (Coordinate y = 0; y <= c_PlayAreaSize - 1; y++) {
 				Coordinates coordinates { x, y };
@@ -409,7 +414,9 @@ namespace Alphalcazar::Game {
 					// The corners of the play area don't exist
 					continue;
 				}
-				action(coordinates, mTiles[x][y]);
+				if (action(coordinates, mTiles[x][y])) {
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Before:
```
[2024-01-08 17:31:09.448] [info] First move at depth 1 took 8ms and calculated a score of 0
[2024-01-08 17:31:09.455] [info] Game at depth 1 took 1ms ended with result 3
[2024-01-08 17:31:09.464] [info] First move at depth 2 took 5ms and calculated a score of -34
[2024-01-08 17:31:09.490] [info] Game at depth 2 took 23ms ended with result 3
[2024-01-08 17:31:09.678] [info] First move at depth 3 took 184ms and calculated a score of 35
[2024-01-08 17:31:11.315] [info] Game at depth 3 took 1635ms ended with result 2
[2024-01-08 17:31:32.946] [info] First move at depth 4 took 21628ms and calculated a score of -64

```

After:
```
[2024-01-08 17:32:00.970] [info] First move at depth 1 took 8ms and calculated a score of 0
[2024-01-08 17:32:00.976] [info] Game at depth 1 took 1ms ended with result 3
[2024-01-08 17:32:00.984] [info] First move at depth 2 took 5ms and calculated a score of -34
[2024-01-08 17:32:01.005] [info] Game at depth 2 took 18ms ended with result 3
[2024-01-08 17:32:01.159] [info] First move at depth 3 took 150ms and calculated a score of 35
[2024-01-08 17:32:02.698] [info] Game at depth 3 took 1535ms ended with result 2
[2024-01-08 17:32:24.301] [info] First move at depth 4 took 21600ms and calculated a score of -64
```